### PR TITLE
Change minimum version to one that supports course_header

### DIFF
--- a/version.php
+++ b/version.php
@@ -12,7 +12,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2013010300; // The current module version (Date: YYYYMMDDXX)
-$plugin->requires  = 2011120500; // Requires this Moodle version
+$plugin->requires  = 2012110900; // Requires this Moodle version
 $plugin->maturity = MATURITY_STABLE;             // this version's maturity level
 $plugin->release = '2.0 (Build: 2013010300)';
 $plugin->component = 'theme_bootstrap'; // Full name of the plugin (used for diagnostics)


### PR DESCRIPTION
Hi, great theme, but it doesn't work on versions of Moodle before this change to outputrenderers.php:

https://github.com/moodle/moodle/commit/fdd4b9a50ad78de738eaf659ec769dcd55d643a4#lib/outputrenderers.php

Here's a patch to add a minimum version number that supports it.

Cheers

Michael
