### PR TITLE
Adding Bootswatch.com setting to override bootsrap css default theme

### DIFF
--- a/lang/en/theme_bootstrap.php
+++ b/lang/en/theme_bootstrap.php
@@ -25,6 +25,8 @@ $string['customcss'] = 'Custom CSS';
 $string['customcssdesc'] = 'Add your extra CSS in this box, use it to customize your theme with a little css';
 $string['gakey'] = 'Google analytics key';
 $string['gakeydesc'] = 'Please enter you Google Analytics key';
+$string['bootswatch_theme'] = 'BoostWatch theme URL';
+$string['bootswatch_themedesc'] = 'Type complete url of your CSS file boostwatch theme.';
 
 $string['choosereadme'] = '
 <div class="clearfix"><div class="theme_screenshot"><h2>Bootstrap</h2>

--- a/lang/es/theme_bootstrap.php
+++ b/lang/es/theme_bootstrap.php
@@ -23,6 +23,8 @@ $string['customcss'] = 'CSS personalizada';
 $string['customcssdesc'] = 'Añade en este campo las configuraciones extras de tu CSS, hazlo para personalizar tu tema con un poco de CSS';
 $string['gakey'] = 'Clave de Google Analytics';
 $string['gakeydesc'] = 'Por favor, introduce tu clave de Google Analytics';
+$string['bootswatch_theme'] = 'URL del tema de BoostWatch';
+$string['bootswatch_themedesc'] = 'Teclea la URL completa del archivo CSS del tema de boostwatch.';
 
 $string['choosereadme'] = '
 <div class="clearfix"><div class="theme_screenshot"><h2>Bootstrap</h2>

--- a/layout/general.php
+++ b/layout/general.php
@@ -52,6 +52,9 @@ $doctype = $OUTPUT->doctype() ?>
     if (!empty($PAGE->theme->settings->gakey)) {
     include($CFG->dirroot . "/theme/bootstrap/layout/google_analytics.php"); 
     };?>
+    <?php if (!empty($PAGE->theme->settings->bootswatch_theme)) {?>
+        <link rel="stylesheet" type="text/css" href="<?php echo $PAGE->theme->settings->bootswatch_theme; ?>">
+    <?php }; ?>
 </head>
 
 <body id="<?php p($PAGE->bodyid) ?>" class="<?php p($PAGE->bodyclasses.' '.join(' ', $bodyclasses)) ?>">

--- a/settings.php
+++ b/settings.php
@@ -54,4 +54,11 @@ if ($ADMIN->fulltree) {
 	$setting = new admin_setting_configtext($name, $title, $description, '');
 	$settings->add($setting);
 
+    $name= 'theme_bootstrap/bootswatch_theme';
+    $title = get_string('bootswatch_theme', 'theme_bootstrap');
+    $description = get_string('bootswatch_themedesc', 'theme_bootstrap');
+    $default = '';
+    $setting = new admin_setting_configtext($name, $title, $description, $default, PARAM_URL);
+    $settings->add($setting);
+
 }


### PR DESCRIPTION
You can find themes here http://bootswatch.com/

All you have to do is to download bootstrap.min.css for the theme you like and put it on your Bootstrap Theme Setting in Moodle. You can see a sample of working theme at http://www.cobachpuertomorelos.com/mod im using http://bootswatch.com/cosmo/

By the way excelent theme.
