### PR TITLE
extra classes for dragging blocks

### DIFF
--- a/layout/general.php
+++ b/layout/general.php
@@ -104,8 +104,10 @@ $doctype = $OUTPUT->doctype() ?>
 
 
 <?php if ($hassidepre) { ?>
-	<div class="span3">
+	<div id=region-pre class="span3 block-region">
+    <div class=region-content>
 	<?php echo $OUTPUT->blocks_for_region('side-pre') ?>
+    </div>
 	</div>
 <?php } ?>
 
@@ -123,8 +125,10 @@ $doctype = $OUTPUT->doctype() ?>
 	</div>
              
 <?php if ($hassidepost) { ?>                
-	<div class="span3">
+	<div id=region-post class="span3 block-region">
+    <div class=region-content>
 	<?php echo $OUTPUT->blocks_for_region('side-post') ?>
+    </div>
     </div>
 <?php }; ?>          
 </div>


### PR DESCRIPTION
When in edit mode you should be able to grab the title of a block and move it around using javascript.

As per usual, any change in the HTML breaks these things in Moodle.

The region-content div seems particularly pointless, and ideally these classes wouldn't be hard-coded into the JS anyway, but this pull request should get it working again.
