### PR TITLE
change alert-error to alert-danger

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -33,7 +33,7 @@ class theme_bootstrap_core_renderer extends core_renderer {
         $type = '';
 
         if ($classes == 'notifyproblem') {
-            $type = 'alert alert-error';
+            $type = 'alert alert-danger';
         }
         if ($classes == 'notifysuccess') {
             $type = 'alert alert-success';


### PR DESCRIPTION
This is required for v3 but it actually also works in Bootstrap 2 as
alert-error and alert-danger used to do the same thing, now only danger
works
