### PR TITLE
remove ie7-inline mixin

### DIFF
--- a/less/moodle/backup-restore.less
+++ b/less/moodle/backup-restore.less
@@ -75,7 +75,6 @@
 .backup-restore .backup-section.settings-section .detail-pair {
     width: 50%;
     display: inline-block;
-    .ie7-inline-block();
 }
 .backup-restore .backup-section.settings-section .detail-pair-label {
     width: 65%;
@@ -97,7 +96,6 @@
 }
 .backup-restore .detail-pair-label {
     display: inline-block;
-    .ie7-inline-block();
     width: 25%;
     padding: 8px;
     margin: 0;
@@ -107,7 +105,6 @@
 }
 .backup-restore .detail-pair-value {
     display: inline-block;
-    .ie7-inline-block();
     width: 65%;
     padding: 8px;
     margin: 0;

--- a/less/moodle/blocks.less
+++ b/less/moodle/blocks.less
@@ -78,7 +78,6 @@
 
 .block.list_block .unlist > li > .column {
     display: inline-block;
-    .ie7-inline-block();
 }
 
 .blockmovetarget,

--- a/less/moodle/filemanager.less
+++ b/less/moodle/filemanager.less
@@ -39,7 +39,6 @@
     .border-radius(8px);
     border: 1px solid #fff;
     display: inline-block;
-    .ie7-inline-block();
     .box-shadow(5px 5px 20px 0 #666);
 }
 #filesskin .yui3-widget-hd {
@@ -61,7 +60,6 @@
     margin: 10px;
     .border-radius(10px);
     display: inline-block;
-    .ie7-inline-block();
     .box-shadow(2px 2px 3px .1px #999);
 }
 
@@ -81,7 +79,6 @@
     width: 180px;
     overflow: auto;
     display: inline-block;
-    .ie7-inline-block();
     float: left;
     height: 525px;
     border-right: 1px solid #BBBBBB;
@@ -323,7 +320,6 @@
 }
 .dir-rtl .fp-pathbar span {
     display: inline-block;
-    .ie7-inline-block();
     float: right;
     margin-left: 32px;
 }
@@ -719,7 +715,6 @@ a.ygtvspacer:hover {
 }
 .fp-select .fp-fileinfo {
     display: inline-block;
-    .ie7-inline-block();
     margin-top: 10px;
 }
 .file-picker.fp-select .fp-fileinfo {
@@ -1097,7 +1092,6 @@ a.ygtvspacer:hover {
 .filemanager.fp-select.fp-cansetmain .fp-file-setmain,
 .filemanager.fp-select.fp-cansetmain .fp-file-setmain-help {
     display: inline-block;
-    .ie7-inline-block();
 }
 .filemanager .fp-mainfile .fp-filename {
     font-weight: bold;

--- a/less/moodle/mixins.less
+++ b/less/moodle/mixins.less
@@ -1,9 +1,5 @@
 // IE7 inline-block
 // ----------------
-.ie7-inline-block() {
-  *display: inline; /* IE7 inline-block hack */
-  *zoom: 1;
-}
 .border-radius(@radius) {
   -webkit-border-radius: @radius;
      -moz-border-radius: @radius;


### PR DESCRIPTION
Bootstrap 3 no longer supports ie7, so we can ditch this mixin
