### PR TITLE
start on admin renderers

### DIFF
--- a/renderers.php
+++ b/renderers.php
@@ -24,5 +24,7 @@
  */
 
 require_once('renderers/core_renderer.php');
+require_once('renderers/maintenance_renderer.php');
+require_once('renderers/admin_renderer.php');
 
 

--- a/renderers/admin_renderer.php
+++ b/renderers/admin_renderer.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of The Bootstrap 3 Moodle theme
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Renderers to align Moodle's HTML with that expected by Bootstrap
+ *
+ * @package    theme_bootstrap
+ * @copyright  2012
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once($CFG->dirroot . "/admin/renderer.php");
+
+class theme_bootstrap_core_admin_renderer extends core_admin_renderer {
+
+    protected function maturity_info($maturity) {
+        if ($maturity == MATURITY_STABLE) {
+            return ''; // No worries.
+        }
+
+        if ($maturity == MATURITY_ALPHA) {
+            $notify_level = 'notifyproblem';
+        } else {
+            $notify_level = 'notifywarning';
+        }
+
+        $maturitylevel = get_string('maturity' . $maturity, 'admin');
+        $warningtext = get_string('maturitycoreinfo', 'admin', $maturitylevel);
+        $doc_link = $this->doc_link('admin/versions', get_string('morehelp'));
+
+        return $this->notification($warningtext . ' ' . $doc_link, $notify_level);
+    }
+
+    protected function maturity_warning($maturity) {
+        if ($maturity == MATURITY_STABLE) {
+            return ''; // No worries.
+        }
+
+        $maturitylevel = get_string('maturity' . $maturity, 'admin');
+        $maturity_warning = get_string('maturitycorewarning', 'admin', $maturitylevel);
+        $maturity_warning .= $this->doc_link('admin/versions', get_string('morehelp'));
+
+        return $this->notification($maturity_warning, 'notifyproblem');
+    }
+
+    /**
+     * Output a warning message, of the type that appears on the admin notifications page.
+     * @param string $message the message to display.
+     * @param string $type type class
+     * @return string HTML to output.
+     */
+    protected function warning($message, $type = 'warning') {
+        if ($type == 'warning') {
+            return $this->notification($message, 'notifywarning');
+        } else if ($type == 'error') {
+            return $this->notification($message, 'notifyproblem');
+        }
+    }
+
+    protected function test_site_warning($testsite) {
+        if (!$testsite) {
+            return '';
+        }
+        $warningtext = get_string('testsiteupgradewarning', 'admin', $testsite);
+        return $this->notification($warningtext, 'notifyproblem');
+    }
+
+    protected function release_notes_link() {
+        $releasenoteslink = get_string('releasenoteslink', 'admin', 'http://docs.moodle.org/dev/Releases');
+        return $this->notification($releasenoteslink, 'notifymessage');
+    }
+}

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -30,21 +30,23 @@ class theme_bootstrap_core_renderer extends core_renderer {
      */
     public function notification($message, $classes = 'notifyproblem') {
         $message = clean_text($message);
-        $type = '';
 
         if ($classes == 'notifyproblem') {
-            $type = 'alert alert-danger';
+            return html_writer::div($message, 'alert alert-danger');
+        }
+        if ($classes == 'notifywarning') {
+            return html_writer::div($message, 'alert alert-warning');
         }
         if ($classes == 'notifysuccess') {
-            $type = 'alert alert-success';
+            return html_writer::div($message, 'alert alert-success');
         }
         if ($classes == 'notifymessage') {
-            $type = 'alert alert-info';
+            return html_writer::div($message, 'alert alert-info');
         }
         if ($classes == 'redirectmessage') {
-            $type = 'alert alert-block alert-info';
+            return html_writer::div($message, 'alert alert-block alert-info');
         }
-        return html_writer::div($message, $type);
+        return html_writer::div($message, $classes);
     }
 
     /*

--- a/renderers/maintenance_renderer.php
+++ b/renderers/maintenance_renderer.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of The Bootstrap 3 Moodle theme
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Renderers to align Moodle's HTML with that expected by Bootstrap
+ *
+ * @package    theme_bootstrap
+ * @copyright  2012
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class theme_bootstrap_core_renderer_maintenance extends core_renderer_maintenance {
+
+    /*
+     * This renders a notification message.
+     * Uses bootstrap compatible html.
+     */
+    public function notification($message, $classes = 'notifyproblem') {
+        $message = clean_text($message);
+
+        if ($classes == 'notifyproblem') {
+            return html_writer::div($message, 'alert alert-danger');
+        }
+        if ($classes == 'notifywarning') {
+            return html_writer::div($message, 'alert alert-warning');
+        }
+        if ($classes == 'notifysuccess') {
+            return html_writer::div($message, 'alert alert-success');
+        }
+        if ($classes == 'notifymessage') {
+            return html_writer::div($message, 'alert alert-info');
+        }
+        if ($classes == 'redirectmessage') {
+            return html_writer::div($message, 'alert alert-block alert-info');
+        }
+        return html_writer::div($message, $classes);
+    }
+}


### PR DESCRIPTION
Note the duplication between maintenance renderer and
core renderer. There's got to be a better way, otherwise that'll
lead to subtle and annoying bugs

I'm also going to try and push some of these admin changes into upstream 2.6
