### PR TITLE
minor style: spaces round =>, underscores in vars

### DIFF
--- a/renderers/admin_renderer.php
+++ b/renderers/admin_renderer.php
@@ -32,16 +32,16 @@ class theme_bootstrap_core_admin_renderer extends core_admin_renderer {
         }
 
         if ($maturity == MATURITY_ALPHA) {
-            $notify_level = 'notifyproblem';
+            $level = 'notifyproblem';
         } else {
-            $notify_level = 'notifywarning';
+            $level = 'notifywarning';
         }
 
         $maturitylevel = get_string('maturity' . $maturity, 'admin');
         $warningtext = get_string('maturitycoreinfo', 'admin', $maturitylevel);
-        $doc_link = $this->doc_link('admin/versions', get_string('morehelp'));
+        $doclink = $this->doc_link('admin/versions', get_string('morehelp'));
 
-        return $this->notification($warningtext . ' ' . $doc_link, $notify_level);
+        return $this->notification($warningtext . ' ' . $doclink, $level);
     }
 
     protected function maturity_warning($maturity) {
@@ -50,10 +50,10 @@ class theme_bootstrap_core_admin_renderer extends core_admin_renderer {
         }
 
         $maturitylevel = get_string('maturity' . $maturity, 'admin');
-        $maturity_warning = get_string('maturitycorewarning', 'admin', $maturitylevel);
-        $maturity_warning .= $this->doc_link('admin/versions', get_string('morehelp'));
+        $maturitywarning = get_string('maturitycorewarning', 'admin', $maturitylevel);
+        $maturitywarning .= $this->doc_link('admin/versions', get_string('morehelp'));
 
-        return $this->notification($maturity_warning, 'notifyproblem');
+        return $this->notification($maturitywarning, 'notifyproblem');
     }
 
     /**

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -184,19 +184,19 @@ class theme_bootstrap_core_renderer extends core_renderer {
                 $usermenu = $menu->add(fullname($USER), new moodle_url('#'), fullname($USER), 10001);
                 $usermenu->add(
                     '<i class="icon-lock"></i>' . get_string('logout'),
-                    new moodle_url('/login/logout.php', array('sesskey'=>sesskey(), 'alt'=>'logout')),
+                    new moodle_url('/login/logout.php', array('sesskey' => sesskey(), 'alt' => 'logout')),
                     get_string('logout')
                 );
 
                 $usermenu->add(
                     '<i class="icon-user"></i>' . get_string('viewprofile'),
-                    new moodle_url('/user/profile.php', array('id'=>$USER->id)),
+                    new moodle_url('/user/profile.php', array('id' => $USER->id)),
                     get_string('viewprofile')
                 );
 
                 $usermenu->add(
                     '<i class="icon-cog"></i>' . get_string('editmyprofile'),
-                    new moodle_url('/user/edit.php', array('id'=>$USER->id)),
+                    new moodle_url('/user/edit.php', array('id' => $USER->id)),
                     get_string('editmyprofile')
                 );
             } else {
@@ -307,7 +307,7 @@ class theme_bootstrap_core_renderer extends core_renderer {
                 $dropdowntype = 'dropdown-submenu';
             }
 
-            $content = html_writer::start_tag('li', array('class'=>$dropdowntype));
+            $content = html_writer::start_tag('li', array('class' => $dropdowntype));
             // If the child has menus render it as a sub menu.
             $submenucount++;
             if ($menunode->get_url() !== null) {
@@ -315,13 +315,13 @@ class theme_bootstrap_core_renderer extends core_renderer {
             } else {
                 $url = '#cm_submenu_'.$submenucount;
             }
-            $link_attributes = array(
-                'href'=>$url,
-                'class'=>'dropdown-toggle',
-                'data-toggle'=>'dropdown',
-                'title'=>$menunode->get_title(),
+            $linkattributes = array(
+                'href' => $url,
+                'class' => 'dropdown-toggle',
+                'data-toggle' => 'dropdown',
+                'title' => $menunode->get_title(),
             );
-            $content .= html_writer::start_tag('a', $link_attributes);
+            $content .= html_writer::start_tag('a', $linkattributes);
             $content .= $menunode->get_text();
             if ($level == 1) {
                 $content .= '<b class="caret"></b>';
@@ -340,7 +340,7 @@ class theme_bootstrap_core_renderer extends core_renderer {
             } else {
                 $url = '#';
             }
-            $content .= html_writer::link($url, $menunode->get_text(), array('title'=>$menunode->get_title()));
+            $content .= html_writer::link($url, $menunode->get_text(), array('title' => $menunode->get_title()));
         }
         return $content;
     }


### PR DESCRIPTION
I updated my Moodle codechecker definitions and these two are new warnings.
