### PR TITLE
Add exec:decache task alias

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,8 +21,8 @@
  * To separately compile only moodle or editor .less files
  * run `grunt less:moodle` or `grunt less:editor` respectively.
  *
- * To only clear the theme caches invoke `grunt exec:decache` in
- * the theme's root directory.
+ * To only clear the theme caches invoke `grunt decache` in the
+ * theme's root directory.
  *
  * Options:
  * The following command-line options can be passed in conjunction


### PR DESCRIPTION
Not a biggie but something which has been bugging me - more of a user-experience tweak than anything else. Provides a more succinct way of invoking the decache task than `grunt exec:decache`:

```
% grunt decache
```
