### PR TITLE
Swatch task for Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -230,7 +230,7 @@ module.exports = function(grunt) {
         // Ensure the swatch directory exists.
         if (!grunt.file.isDir(swatchpath)) {
             message = "The swatch directory '" + swatchpath + "' ";
-            message += 'does not exist.';
+            message += 'does not exist or is not accessible.';
             grunt.fail.fatal(message);
         }
 


### PR DESCRIPTION
I've added a task for switching the current bootswatch compiled with the theme.

I wanted something which would allow me to quickly switch between / compare bootswatches I'd downloaded. The task copies in the swatch files, recompiles the less and clears the theme cache.

We use a directory naming convention to identify swatch names e.g.

```
% grunt swatch --name=superhero
```

...will switch the current custom-bootswatch.less and custom-variables.less with the variables.less and bootswatch.less files contained inside a subdirecory of `less/bootswatch` named `superhero` (`<theme_bootstrap>/less/bootswatch/superhero`).

If you prefer to keep your bootswatches outside the theme directory there's an optional parameter to set the root directory the task looks in for swatch directories e.g.

```
% grunt swatch --name=superhero --swatches-dir=/path/to/swatches/dirroot
```

Sometimes it's desirable to only use the variables.less file for a given swatch - in those instances it's possible to pass in the flag `--vars-only` and custom-variables.less will be updated while custom-bootswatch.less is reset.

```
% grunt swatch --name=superhero --vars-only
```

or 

```
% grunt swatch --vars-only=true --name=superhero
```

I've also given the docblock an overhaul to capture the above and hopefully make the tasks and options clearer.
