### PR TITLE
restore block hiding CSS

### DIFF
--- a/less/moodle/blocks.less
+++ b/less/moodle/blocks.less
@@ -103,6 +103,12 @@
 .block.hidden .block-hider-hide {
     display: none;
 }
+.block.hidden .block-hider-show {
+    display: inline;
+}
+.block.hidden .content {
+    display: none;
+}
 
 .block_calendar_upcoming {
     .footer {


### PR DESCRIPTION
I accidentally deleted this while working on hiding blocks from
students (.invisible) as opposed to this, which lets you hide
blocks from yourself (.hidden)

closes issue #147
