### PR TITLE
Grunt clear bootswatch option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,7 +121,7 @@
  *                                          `--vars-only=true` this option
  *                                          should be passed last.
  *
- *                   --reset                Optional. Reset bootswatch to
+ *                   --none                 Optional. Reset bootswatch to
  *                                          plain Bootstrap (no swatch).
  *
  *
@@ -212,14 +212,14 @@ module.exports = function(grunt) {
         var swatchname = grunt.option('name') || '',
             swatchroot = grunt.option('swatches-dir') || '',
             varsonly   = grunt.option('vars-only'),
-            reset      = grunt.option('reset'),
+            noswatch   = grunt.option('none'),
             list       = grunt.option('list');
 
         // Reset bootwatches for default boootstrap.
-        if (reset) {
+        if (noswatch) {
             grunt.file.write(BOOTSWATCHFILE, '');
             grunt.file.write(BOOTSWATCHVARS, '');
-            grunt.log.writeln('Bootswatch reset.');
+            grunt.log.writeln('Cleared bootswatch.');
             return;
         }
 


### PR DESCRIPTION
Added a swatch option to clear bootswatch discussed a little while ago in #145. Initially I implemented the option as `--reset` but felt that this gave the expectation that the command would reset the theme to it's distribution state which uses Cerulean vars. `--none` seemed clearer that the swatch is completely removed so that afterwards the theme shows vanilla Bootstrap.

```
% grunt swatch --none
```
