### PR TITLE
Make path handling more robust

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,20 +163,20 @@ module.exports = function(grunt) {
         THEMEDIR        = path.basename(path.resolve('.'));
 
     // PHP strings for exec task.
-    var moodleroot = 'dirname(dirname(__DIR__))',
+    var moodleroot = path.dirname(path.dirname(__dirname)),
         configfile = '',
         decachephp = '',
         dirrootopt = grunt.option('dirroot') || '';
 
     // Allow user to explicitly define Moodle root dir.
     if ('' !== dirrootopt) {
-        moodleroot = "realpath('" + dirrootopt + "')";
+        moodleroot = path.resolve(dirrootopt);
     }
 
-    configfile = moodleroot + " . '/config.php'";
+    configfile = path.join(moodleroot, 'config.php');
 
     decachephp += 'define(\'CLI_SCRIPT\', true);';
-    decachephp += 'require(' + configfile  + ');';
+    decachephp += 'require(\'' + configfile  + '\');';
     decachephp += 'theme_reset_all_caches();';
 
     grunt.initConfig({


### PR DESCRIPTION
Following the recent couple of issues related to generation of the paths used in the decaching PHP I wanted to take another look at the path handling and make it a bit more robust and (I hope) easier to read too (the double / single quotes stuff wasn't the easiest on the eyes).

I think it makes much more sense to leverage the node `path` module - probably should have been written that way to begin with.
