### PR TITLE
Font Icon setting, and setting infrastructure

### DIFF
--- a/lang/en/theme_bootstrap.php
+++ b/lang/en/theme_bootstrap.php
@@ -24,8 +24,10 @@
 $string['pluginname'] = 'Bootstrap 3';
 $string['region-side-post'] = 'Right';
 $string['region-side-pre'] = 'Left';
+$string['fonticons'] = 'Use Icon Font';
+$string['fonticonsdesc'] = 'Enable this option to use the Glyphicon Icon Font';
 $string['fluidwidth'] = 'Fluid width theme';
-$string['fluidwidth_desc'] = 'Enable this option to allow using your full screen';
+$string['fluidwidthdesc'] = 'Enable this option to allow using your full screen';
 
 $string['choosereadme'] = '
 <div class="clearfix"><div class="theme_screenshot"><h2>Bootstrap Base</h2>

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -336,15 +336,15 @@ class theme_bootstrap_core_renderer extends core_renderer {
             return html_writer::tag('li', $link);
         }
     }
-/*
     protected function render_pix_icon(pix_icon $icon) {
-        if ($icon->attributes["alt"] === '' && $this->replace_moodle_icon($icon->pix) !== false) {
+        if ($this->page->theme->settings->fonticons === '1'
+            && $icon->attributes["alt"] === ''
+            && $this->replace_moodle_icon($icon->pix) !== false) {
             return $this->replace_moodle_icon($icon->pix);
-        } else {
-            return parent::render_pix_icon($icon);
         }
+        return parent::render_pix_icon($icon);
     }
-*/
+
     protected function replace_moodle_icon($name) {
         $icons = array(
             'add' => 'plus',
@@ -378,6 +378,7 @@ class theme_bootstrap_core_renderer extends core_renderer {
             'i/users' => 'user',
             'spacer' => 'spacer',
             't/add' => 'plus',
+            't/assignroles' => 'user',
             't/copy' => 'plus-sign',
             't/delete' => 'remove',
             't/down' => 'arrow-down',

--- a/settings.php
+++ b/settings.php
@@ -26,11 +26,19 @@
 defined('MOODLE_INTERNAL') || die;
 
 if ($ADMIN->fulltree) {
-    // Turn on fluid width
-    $name = 'theme_bootstrap/fluidwidth';
-    $title = get_string('fluidwidth', 'theme_bootstrap');
-    $description = get_string('fluidwidth_desc', 'theme_bootstrap');
-    $default = '0';
-    $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
-    $settings->add($setting);
+    $settings->add(theme_bootstrap_checkbox('fluidwidth'));
+    $settings->add(theme_bootstrap_checkbox('fonticons'));
+}
+
+function theme_bootstrap_checkbox($setting, $default='0') {
+    list($name, $title, $description) = theme_bootstrap_setting_details($setting);
+    return new admin_setting_configcheckbox($name, $title, $description, $default);
+}
+
+function theme_bootstrap_setting_details($setting) {
+    $theme = "theme_bootstrap";
+    $name = "$theme/$setting";
+    $title = get_string($setting, $theme);
+    $description = get_string($setting.'desc', $theme);
+    return array($name, $title, $description);
 }


### PR DESCRIPTION
Uses a setting to allow, disallow use of Font Icon.

This probably needs tweaked since the Font Icon is used anyway in
some places, and never used in other places. Possibly the option
should be "Use Font Icon for dropdowns" (or maybe that should always
be enforced.

But this is a start on the infrastructure needed for those decisions.

Tried to cut down on the needless repeition in Moodle theme settings
via some "convention over configuration" too. It can get a bit crazy once you 
have as many settings as Elegance.
