### PR TITLE
add customcss setting

### DIFF
--- a/config.php
+++ b/config.php
@@ -29,9 +29,9 @@ $THEME->yuicssmodules = array();
 $THEME->name = 'bootstrap';
 $THEME->parents = array();
 if ('ltr' === get_string('thisdirection', 'langconfig')) {
-    $THEME->sheets = array('moodle');
+    $THEME->sheets = array('moodle', 'custom');
 } else {
-    $THEME->sheets = array('moodle-rtl', 'tinymce-rtl', 'yui2-rtl', 'forms-rtl');
+    $THEME->sheets = array('moodle-rtl', 'tinymce-rtl', 'yui2-rtl', 'forms-rtl', 'custom');
 }
 $THEME->supportscssoptimisation = false;
 
@@ -48,6 +48,7 @@ $THEME->plugins_exclude_sheets = array(
 );
 
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';
+$THEME->csspostprocess = 'theme_bootstrap_process_css';
 
 $THEME->layouts = array(
     // Most backwards compatible layout without the blocks - this is the layout used by default.
@@ -66,7 +67,7 @@ $THEME->layouts = array(
         'file' => 'default.php',
         'regions' => array('side-pre', 'side-post'),
         'defaultregion' => 'side-pre',
-        'options' => array('langmenu'=>true),
+        'options' => array('langmenu' => true),
     ),
     'coursecategory' => array(
         'file' => 'default.php',
@@ -84,21 +85,21 @@ $THEME->layouts = array(
         'file' => 'default.php',
         'regions' => array('side-pre', 'side-post'),
         'defaultregion' => 'side-pre',
-        'options' => array('nonavbar'=>true),
+        'options' => array('nonavbar' => true),
     ),
     // Server administration scripts.
     'admin' => array(
         'file' => 'default.php',
         'regions' => array('side-pre'),
         'defaultregion' => 'side-pre',
-    	'options' => array('fluid'=>true),
+        'options' => array('fluid' => true),
     ),
     // My dashboard page.
     'mydashboard' => array(
         'file' => 'default.php',
         'regions' => array('side-pre', 'side-post'),
         'defaultregion' => 'side-pre',
-        'options' => array('langmenu'=>true),
+        'options' => array('langmenu' => true),
     ),
     // My public page.
     'mypublic' => array(
@@ -109,20 +110,20 @@ $THEME->layouts = array(
     'login' => array(
         'file' => 'default.php',
         'regions' => array(),
-        'options' => array('langmenu'=>true, 'nonavbar'=>true),
+        'options' => array('langmenu' => true, 'nonavbar' => true),
     ),
 
     // Pages that appear in pop-up windows - no navigation, no blocks, no header.
     'popup' => array(
         'file' => 'popup.php',
         'regions' => array(),
-        'options' => array('nofooter'=>true, 'nonavbar'=>true),
+        'options' => array('nofooter' => true, 'nonavbar' => true),
     ),
     // No blocks and minimal footer - used for legacy frame layouts only!
     'frametop' => array(
         'file' => 'default.php',
         'regions' => array(),
-        'options' => array('nofooter'=>true, 'nocoursefooter'=>true),
+        'options' => array('nofooter' => true, 'nocoursefooter' => true),
     ),
     // Embeded pages, like iframe/object embeded in moodleform - it needs as much space as possible.
     'embedded' => array(
@@ -140,7 +141,7 @@ $THEME->layouts = array(
     'print' => array(
         'file' => 'default.php',
         'regions' => array(),
-        'options' => array('nofooter'=>true, 'nonavbar'=>false),
+        'options' => array('nofooter' => true, 'nonavbar' => false),
     ),
     // The pagelayout used when a redirection is occuring.
     'redirect' => array(
@@ -152,7 +153,7 @@ $THEME->layouts = array(
         'file' => 'default.php',
         'regions' => array('side-pre'),
         'defaultregion' => 'side-pre',
-    	'options' => array('fluid'=>true),
+        'options' => array('fluid' => true),
     ),
     // The pagelayout used for safebrowser and securewindow.
     'secure' => array(

--- a/lang/en/theme_bootstrap.php
+++ b/lang/en/theme_bootstrap.php
@@ -24,6 +24,8 @@
 $string['pluginname'] = 'Bootstrap 3';
 $string['region-side-post'] = 'Right';
 $string['region-side-pre'] = 'Left';
+$string['customcss'] = 'Custom CSS';
+$string['customcssdesc'] = 'Whatever CSS rules you add to this textarea will be reflected in every page, making for easier customization of this theme.';
 $string['fonticons'] = 'Use Icon Font';
 $string['fonticonsdesc'] = 'Enable this option to use the Glyphicon Icon Font';
 $string['fluidwidth'] = 'Fluid width theme';

--- a/lib.php
+++ b/lib.php
@@ -52,10 +52,76 @@ function theme_bootstrap_checkbox($setting, $default='0') {
     return new admin_setting_configcheckbox($name, $title, $description, $default);
 }
 
+function theme_bootstrap_textarea($setting, $default='') {
+    list($name, $title, $description) = theme_bootstrap_setting_details($setting);
+    return new admin_setting_configtextarea($name, $title, $description, $default);
+}
+
 function theme_bootstrap_setting_details($setting) {
     $theme = "theme_bootstrap";
     $name = "$theme/$setting";
     $title = get_string($setting, $theme);
     $description = get_string($setting.'desc', $theme);
     return array($name, $title, $description);
+}
+
+/**
+ * Parses CSS before it is cached.
+ *
+ * This function can make alterations and replace patterns within the CSS.
+ *
+ * @param string $css The CSS
+ * @param theme_config $theme The theme config object.
+ * @return string The parsed CSS The parsed CSS.
+ */
+function theme_bootstrap_process_css($css, $theme) {
+
+    $defaultsettings = array(
+        'customcss' => '',
+    );
+
+    $settings = theme_bootstrap_get_user_settings($defaultsettings, $theme);
+
+    return theme_bootstrap_replace_settings($settings, $css);
+}
+
+/**
+ * Parses CSS before it is cached.
+ *
+ * This function can make alterations and replace patterns within the CSS.
+ *
+ * @param array $settings containing setting names and default values
+ * @param theme_config $theme The theme config object.
+ * @return array The setting with defaults replaced with user settings (if any)
+ */
+function theme_bootstrap_get_user_settings($settings, $theme) {
+    foreach (array_keys($settings) as $setting) {
+        if (!empty($theme->settings->$setting)) {
+            $settings[$setting] = $theme->settings->$setting;
+        }
+    }
+    return $settings;
+}
+
+/**
+ * For each setting called e.g. "customcss" this looks for the string
+ * "[[setting:customcss]]" in the CSS and replaces it with
+ * the value held in the $settings array for the key
+ * "customcss".
+ *
+ * @param array $settings containing setting names and values
+ * @param string $css The CSS
+ * @return string The CSS with replacements made
+ */
+function theme_bootstrap_replace_settings($settings, $css) {
+    $settingnames = array_keys($settings);
+
+    $wrapsettings = function($name) {
+        return "[[setting:$name]]";
+    };
+
+    $find = array_map($wrapsettings, $settingnames);
+    $replace = array_values($settings);
+
+    return str_replace($find, $replace, $css);
 }

--- a/settings.php
+++ b/settings.php
@@ -31,5 +31,6 @@ if ($ADMIN->fulltree) {
     $settings->add(theme_bootstrap_checkbox('fluidwidth'));
     $settings->add(theme_bootstrap_checkbox('fonticons'));
     $settings->add(theme_bootstrap_checkbox('inversenavbar'));
-}
 
+    $settings->add(theme_bootstrap_textarea('customcss'));
+}

--- a/style/custom.css
+++ b/style/custom.css
@@ -1,0 +1,1 @@
+[[setting:customcss]]


### PR DESCRIPTION
The search and replace stuff could be simplified I think.
When you set up a setting you provide Moodle with a default setting,
yet most of the themes I see seem to check if its set and then
manually add this default value. Perhaps you can ask Moodle for it,
since it already knows what it is.

Also fixed some warning about => I was getting in config.php
