### PR TITLE
use Grunt to correct the glyphicon replace format

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,9 @@
  *                           that require flipping for use with RTL
  *                           languages.
  *
+ * grunt replace:font_fix    Correct the format for the Moodle font
+ *                           loader to pick up the Glyphicon font.
+ *
  * grunt replace:svg_colors  Change the color of the SVGs in pix_core by
  *                           text replacing #999 with a new hex color.
  *                           Note this requires the SVGs to be #999 to
@@ -307,6 +310,23 @@ module.exports = function(grunt) {
                         from: '#999',
                         to: svgcolor
                     }]
+            },
+            font_fix: {
+                src: 'style/moodle.css',
+                    overwrite: true,
+                    replacements: [{
+                        from: 'glyphicons-halflings-regular.eot',
+                        to: 'glyphicons-halflings-regular.eot]]',
+                    }, {
+                        from: 'glyphicons-halflings-regular.svg',
+                        to: 'glyphicons-halflings-regular.svg]]',
+                    }, {
+                        from: 'glyphicons-halflings-regular.ttf',
+                        to: 'glyphicons-halflings-regular.ttf]]',
+                    }, {
+                        from: 'glyphicons-halflings-regular.woff',
+                        to: 'glyphicons-halflings-regular.woff]]',
+                    }]
             }
         }
     });
@@ -391,7 +411,7 @@ module.exports = function(grunt) {
     grunt.registerTask("decache", ["exec:decache"]);
 
     grunt.registerTask("bootswatch", _bootswatch);
-    grunt.registerTask("compile", ["less", "cssflip", "replace:rtl_images", "decache"]);
+    grunt.registerTask("compile", ["less", "replace:font_fix", "cssflip", "replace:rtl_images", "decache"]);
     grunt.registerTask("swatch", ["bootswatch", "svg", "compile"]);
     grunt.registerTask("svg", ["copy:svg", "replace:svg_colors"]);
 };

--- a/less/editor.less
+++ b/less/editor.less
@@ -12,8 +12,6 @@
 @import "bootstrap3/tables.less";
 
 // Components: common.
-@iconSpritePath:          ~"[[pix:theme|glyphicons-halflings]]";
-@iconWhiteSpritePath:     ~"[[pix:theme|glyphicons-halflings-white]]";
 @import "bootstrap3/wells.less";
 
 // Components: Buttons & Alerts.

--- a/less/moodle.less
+++ b/less/moodle.less
@@ -41,6 +41,8 @@
 @import "bootswatch/custom-variables.less";
 @import "bootswatch/custom-bootswatch.less";
 
+@icon-font-path: "[[font:theme|";
+
 // Anything below this line is considered expendable,
 // so it doesn't matter if it doesn't show up in ie < 9
 // though at current time (2013-03-13) the whole file is

--- a/less/moodle/bootstrapoverride.less
+++ b/less/moodle/bootstrapoverride.less
@@ -12,16 +12,7 @@
   }
 }
 
-// glyphicons.less
-// Import the fonts
-@font-face {
-  font-family: 'Glyphicons Halflings';
-  src: url('[[font:theme|@{icon-font-name}.eot]]');
-  src: url('[[font:theme|@{icon-font-name}.eot]]') format('embedded-opentype'),
-       url('[[font:theme|@{icon-font-name}.woff]]') format('woff'),
-       url('[[font:theme|@{icon-font-name}.ttf]]') format('truetype'),
-       url('[[font:theme|@{icon-font-name}.svg]]#glyphicons_halflingsregular') format('svg');
-}
+@icon-font-path: "[[font:theme|";
 
 .moodleSkin .mceIcon img.mceIcon {
     display: block;

--- a/lib.php
+++ b/lib.php
@@ -49,12 +49,16 @@ function bootstrap_grid($hassidepre, $hassidepost) {
 
 function theme_bootstrap_checkbox($setting, $default='0') {
     list($name, $title, $description) = theme_bootstrap_setting_details($setting);
-    return new admin_setting_configcheckbox($name, $title, $description, $default);
+    $setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    return $setting;
 }
 
 function theme_bootstrap_textarea($setting, $default='') {
     list($name, $title, $description) = theme_bootstrap_setting_details($setting);
-    return new admin_setting_configtextarea($name, $title, $description, $default);
+    $setting = new admin_setting_configtextarea($name, $title, $description, $default);
+    $setting->set_updatedcallback('theme_reset_all_caches');
+    return $setting;
 }
 
 function theme_bootstrap_setting_details($setting) {

--- a/style/moodle-rtl.css
+++ b/style/moodle-rtl.css
@@ -11341,8 +11341,8 @@ input[type="button"].btn-block {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]?#iefix') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff]]') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf]]') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg]]#glyphicons_halflingsregular') format('svg');
 }
 
 .glyphicon {
@@ -15563,12 +15563,6 @@ button.close {
   a[href]:after {
     content: "";
   }
-}
-
-@font-face {
-  font-family: 'Glyphicons Halflings';
-  src: url('[[font:theme|glyphicons-halflings-regular.eot]]');
-  src: url('[[font:theme|glyphicons-halflings-regular.eot]]') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff]]') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf]]') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg]]#glyphicons_halflingsregular') format('svg');
 }
 
 .moodleSkin .mceIcon img.mceIcon {

--- a/style/moodle.css
+++ b/style/moodle.css
@@ -9288,8 +9288,8 @@ input[type="button"].btn-block {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('../fonts/glyphicons-halflings-regular.eot');
-  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]?#iefix') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff]]') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf]]') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg]]#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -12756,11 +12756,6 @@ button.close {
   a[href]:after {
     content: "";
   }
-}
-@font-face {
-  font-family: 'Glyphicons Halflings';
-  src: url('[[font:theme|glyphicons-halflings-regular.eot]]');
-  src: url('[[font:theme|glyphicons-halflings-regular.eot]]') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff]]') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf]]') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg]]#glyphicons_halflingsregular') format('svg');
 }
 .moodleSkin .mceIcon img.mceIcon {
   display: block;


### PR DESCRIPTION
The CSS post_process step is too late to fix this, changing the
upstream code is bad practice, the current CSS overrule leaves a
broken font link in the CSS.

None of the solutions are particularly good, but since we're already
using grunt we might as well fix this with it too.
