### PR TITLE
simple settings class

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -25,11 +25,12 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot . '/theme/' . "/bootstrap/lib.php");
+require_once(__DIR__ . "/lib.php");
 
 if ($ADMIN->fulltree) {
-    $settings->add(theme_bootstrap_checkbox('fluidwidth'));
-    $settings->add(theme_bootstrap_checkbox('fonticons'));
-    $settings->add(theme_bootstrap_checkbox('inversenavbar'));
-    $settings->add(theme_bootstrap_textarea('customcss'));
+    $simplesettings = new simple_settings($settings, 'theme_bootstrap');
+    $simplesettings->add_checkbox('fluidwidth');
+    $simplesettings->add_checkbox('fonticons');
+    $simplesettings->add_checkbox('inversenavbar');
+    $simplesettings->add_textarea('customcss');
 }


### PR DESCRIPTION
Put the stuff for simplifying theme settings in a class to keep it
tidy, particularly as Moodle suggests functions should all start
with the full themename.

Use **DIR** for locating theme local files in requires.

Also, dropped the over fancy and frankly unnecessary use of an
anonymous function and array_map in the CSS setting swap code for
a simple foreach, as it is simpler, shorter and more readable.
