### PR TITLE
Style fatal errors better

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -44,7 +44,16 @@ class theme_bootstrap_core_renderer extends core_renderer {
         if ($classes == 'redirectmessage') {
             return html_writer::div($message, 'alert alert-block alert-info');
         }
+        if ($classes == 'notifytiny') {
+            // Not an appropriate semantic alert class!
+            return $this->debug_listing($message);
+        }
         return html_writer::div($message, $classes);
+    }
+
+    private function debug_listing($message) {
+        $message = str_replace('<ul style', '<ul class="list-unstyled" style', $message);
+        return html_writer::tag('pre', $message, array('class' => 'alert alert-info'));
     }
 
     public function navbar() {
@@ -398,5 +407,11 @@ class theme_bootstrap_core_renderer extends core_renderer {
         } else {
             return false;
         }
+    }
+    public function box($contents, $classes = 'generalbox', $id = null, $attributes = array()) {
+        if (isset($attributes['data-rel']) && $attributes['data-rel'] === 'fatalerror') {
+            return html_writer::div($contents, 'alert alert-danger', $attributes);
+        }
+        return parent::box($contents, $classes, $id, $attributes);
     }
 }


### PR DESCRIPTION
To test try editing a URL to visit a section of the settings
that doesn't exist or a really high course id number. With
debug up full you see the debug info too.

Turns fatal errors into alert-dangers, and debug info into
pre.alert-infos.

The debug info just picks up on the (somewhat random) use of
notifytiny as a notification class. It also restyles it slightly
by rewriting the HTML, rather than add extra CSS just for debug
styles.

The fatal error stuff comes from deep within a scary renderer,
but by catching it in the box renderer I can divert it. This is an
interesting technique with possibiities for catching other stuff
that's either not in a renderer or in a really ugly renderer that
we'd rather not touch.
