### PR TITLE
simplify settings.

### DIFF
--- a/layout/default.php
+++ b/layout/default.php
@@ -33,29 +33,15 @@ if ($usereader) {
     $navbarbtn = $OUTPUT->navbar_button_reader('#region-main', 'hidden-xs');
 }
 
-$fluid = (!empty($PAGE->layout_options['fluid']));
-$container = 'container';
-if (isset($PAGE->theme->settings->fluidwidth) && ($PAGE->theme->settings->fluidwidth == true)) {
-    $container = 'container-fluid';
-}
-if ($fluid) {
-    $container = 'container-fluid';
-}
-
-$brandfont = $PAGE->theme->settings->brandfont;
-
-$navbarclass = 'navbar navbar-default';
-if ($PAGE->theme->settings->inversenavbar == true) {
-    $navbarclass = 'navbar navbar-inverse';
-}
+$settingshtml = theme_bootstrap_html_for_settings($PAGE);
 
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
     <title><?php echo $OUTPUT->page_title(); ?></title>
     <link rel="shortcut icon" href="<?php echo $OUTPUT->favicon(); ?>" />
-    <?php echo theme_bootstrap_brand_font_link($SITE->shortname, $brandfont) ?>
-    <?php echo $OUTPUT->standard_head_html() ?>
+    <?php echo $settingshtml->brandfontlink; ?>
+    <?php echo $OUTPUT->standard_head_html(); ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
 </head>
 
@@ -63,8 +49,8 @@ echo $OUTPUT->doctype() ?>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 
-<nav role="navigation" class="<?php echo $navbarclass ?>">
-    <div class="<?php echo $container; ?>">
+<nav role="navigation" class="<?php echo $settingshtml->navbarclass; ?>">
+    <div class="<?php echo $settingshtml->containerclass; ?>">
     <div class="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#moodle-navbar">
             <span class="sr-only">Toggle navigation</span>
@@ -86,12 +72,12 @@ echo $OUTPUT->doctype() ?>
     </div>
 </nav>
 <header class="moodleheader">
-<div class="<?php echo $container; ?>">
+<div class="<?php echo $settingshtml->containerclass; ?>">
 <?php echo $OUTPUT->page_heading(); ?>
 </div>
 </header>
 
-<div id="page" class="<?php echo $container; ?>">
+<div id="page" class="<?php echo $settingshtml->containerclass; ?>">
     <header id="page-header" class="clearfix">
         <div id="page-navbar" class="clearfix">
             <nav class="breadcrumb-nav" role="navigation" aria-label="breadcrumb"><?php echo $OUTPUT->navbar(); ?></nav>

--- a/layout/secure.php
+++ b/layout/secure.php
@@ -21,18 +21,14 @@ $regions = bootstrap_grid($hassidepre, $hassidepost);
 $PAGE->requires->jquery();
 $PAGE->requires->jquery_plugin('bootstrap', 'theme_bootstrap');
 
-$brandfont = $PAGE->theme->settings->brandfont;
+$settingshtml = theme_bootstrap_html_for_settings($PAGE);
 
-$navbarclass = 'navbar navbar-default';
-if ($PAGE->theme->settings->inversenavbar == true) {
-    $navbarclass = 'navbar navbar-inverse';
-}
 echo $OUTPUT->doctype() ?>
 <html <?php echo $OUTPUT->htmlattributes(); ?>>
 <head>
     <title><?php echo $OUTPUT->page_title(); ?></title>
     <link rel="shortcut icon" href="<?php echo $OUTPUT->favicon(); ?>" />
-    <?php echo theme_bootstrap_brand_font_link($SITE->shortname, $brandfont) ?>
+    <?php echo $settingshtml->brandfontlink; ?>
     <?php echo $OUTPUT->standard_head_html() ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
 </head>
@@ -41,7 +37,7 @@ echo $OUTPUT->doctype() ?>
 
 <?php echo $OUTPUT->standard_top_of_body_html() ?>
 
-<nav role="navigation" class="<?php echo $navbarclass ?>">
+<nav role="navigation" class="<?php echo $settingshtml->navbarclass ?>">
     <div class="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#moodle-navbar">
             <span class="sr-only">Toggle navigation</span>

--- a/settings.php
+++ b/settings.php
@@ -26,13 +26,13 @@
 defined('MOODLE_INTERNAL') || die;
 
 require_once(__DIR__ . "/lib.php");
+require_once(__DIR__ . "/simple_theme_settings.class.php");
 
 if ($ADMIN->fulltree) {
-    $simplesettings = new simple_settings($settings, 'theme_bootstrap');
+    $simplesettings = new simple_theme_settings($settings, 'theme_bootstrap');
     $simplesettings->add_checkbox('fluidwidth');
     $simplesettings->add_checkbox('fonticons');
     $simplesettings->add_checkbox('inversenavbar');
     $simplesettings->add_text('brandfont');
     $simplesettings->add_textarea('customcss');
-    $simplesettings->add_numbered_textareas('footerwidget', 4);
 }

--- a/simple_theme_settings.class.php
+++ b/simple_theme_settings.class.php
@@ -1,0 +1,156 @@
+<?php
+// This file is part of The Bootstrap 3 Moodle theme
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * A wrapper round Moodle's settings API to simplify the common cases
+ * for themers, often via "convention over configuration" and the reduction
+ * in repetitive typing
+ *
+ * Assumes all strings are in the theme lang file, assumes the title
+ * langstring is the same as the name, and that the description langstring
+ * is the same as the title with 'desc' added to the end.
+ *
+ * @package    theme_bootstrap
+ * @copyright  2014 Bas Brands, www.basbrands.nl
+ * @authors    Bas Brands, David Scotson
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+class simple_theme_settings {
+    private $themename;
+    private $settingspage;
+
+    public function __construct($settingspage, $themename) {
+        $this->themename = $themename;
+        $this->settingspage = $settingspage;
+    }
+
+    private function name_for($setting, $suffix='') {
+        return $this->themename.'/'.$setting.$suffix;
+    }
+
+    private function title_for($setting, $additional = null) {
+        return get_string($setting, $this->themename, $additional);
+    }
+
+    private function description_for($setting) {
+        return get_string($setting.'desc', $this->themename);
+    }
+
+    public function add_checkbox($setting, $default='0', $checked='1', $unchecked='0') {
+        $checkbox = new admin_setting_configcheckbox(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default,
+            $checked,
+            $unchecked
+        );
+        $checkbox->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($checkbox);
+    }
+
+    public function add_text($setting, $default='') {
+        $text = new admin_setting_configtext(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default
+        );
+        $text->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($text);
+    }
+    public function add_heading($setting) {
+        $heading = new admin_setting_heading(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting)
+        );
+        $this->settingspage->add($heading);
+    }
+
+    public function add_select($setting, $default, $options) {
+        $select = new admin_setting_configselect(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default,
+            $options
+        );
+        $select->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($select);
+    }
+
+    public function add_textarea($setting, $default='') {
+        $textarea = new admin_setting_configtextarea(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default
+        );
+        $textarea->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($textarea);
+    }
+
+    public function add_htmleditor($setting, $default='') {
+        $htmleditor = new admin_setting_confightmleditor(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default
+        );
+        $htmleditor->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($htmleditor);
+    }
+    public function add_colourpicker($setting, $default='#666') {
+        $colorpicker = new admin_setting_configcolourpicker(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $default,
+            null // Don't hook up any javascript preview of color change.
+        );
+        $colorpicker->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($colorpicker);
+    }
+    public function add_file($setting) {
+        $file = new admin_setting_configstoredfile(
+            $this->name_for($setting),
+            $this->title_for($setting),
+            $this->description_for($setting),
+            $setting // TODO find out what this does,
+                     // for now assume it just needs to be unique.
+        );
+        $file->set_updatedcallback('theme_reset_all_caches');
+        $this->settingspage->add($file);
+    }
+    public function add_numbered_textareas($setting, $count, $default='') {
+        for ($i = 1; $i <= $count; $i++) {
+            $textarea = new admin_setting_configtextarea(
+                $this->name_for($setting, $i),
+                $this->title_for($setting, $i),
+                $this->description_for($setting),
+                $default
+            );
+            $textarea->set_updatedcallback('theme_reset_all_caches');
+            $this->settingspage->add($textarea);
+        }
+    }
+}
+


### PR DESCRIPTION
The simple_settings class has been moved to its own php file
and renamed simple_theme_settings.

Started moving all theme HTML generation logic back into the lib.php
file so the layout file just needs to echo the final HTML. This
idea was inspired by Julian's approach with the Elegance theme.

Possibly the bootstrap grid stuff could use this method as well.

Simplified the CSS replacement function so you no longer need to
specify the settings or the defaults, it'll automatically grab all
settings it finds for the theme.

Rearranged the lib.php file to put related stuff together, mostly
CSS at the top, HTML at the bottom.
