### PR TITLE
remove hardcoded colors from course management

### DIFF
--- a/less/moodle/course.less
+++ b/less/moodle/course.less
@@ -667,50 +667,44 @@ span.editinstructions {
     }
 }
 
-/**
- * Course management page
- * Palette
- *
- * Background (reg)         #f5f5f5
- * Background (light        #fafafa
- * Background (highlight)   #dfa
- * Borders                  #e1e1e8
- */
+// colors updated from core, now
+// using table color variables mostly
 #course-category-listings {
-    background-color:#fff;
-    margin-bottom:200px;
+    background-color: @table-bg;
+    margin-bottom: 200px;
 
     /** Two column layout */
     &.columns-2 {
         > #course-listing > div {
-            position:relative;
-            left:-1px;
+            position: relative;
+            left: -1px;
         }
     }
     /** Three column layout */
     &.columns-3 > #course-listing > div {
-        height:100%;
+        height: 100%;
     }
 
     > div > div {
-        min-height:300px;
-        border:1px solid #e1e1e8;
+        min-height: 300px;
+        border: 1px solid @table-border-color;
         > ul.ml > li:first-child > div {
-            border-top:0;
+            border-top: 0;
         }
     }
     h3 {
-        margin:0;
-        padding:0.4rem 0.6rem 0.3rem;
-        background-color:#f5f5f5;
-        border-bottom:1px solid #e1e1e8;
+        margin: 0;
+        padding: .4rem .6rem .3rem;
+        background-color: @panel-default-heading-bg;
+        color: @panel-default-text;
+        border-bottom: 1px solid @panel-inner-border;
     }
     h4 {
-        margin:1rem 0 0;
-        padding:0.6rem 1rem 0.5rem;
+        margin: 1rem 0 0;
+        padding: .6rem 1rem .5rem;
     }
     .moodle-actionmenu {
-        white-space:nowrap;
+        white-space: nowrap;
     }
 
     .moodle-actionmenu[data-enhance] {
@@ -729,63 +723,65 @@ span.editinstructions {
     }
 
     .listing-actions {
-        text-align:center;
-        padding:0.4rem 0.3rem 0.3rem;
-        line-height:2.2em;
+        text-align: center;
+        padding: .4rem .3rem .3rem;
+        line-height: 2.2em;
         > .moodle-actionmenu {
-            display:inline-block;
+            display: inline-block;
             .menu a {
-                padding-left:1rem;
+                padding-left: 1rem;
             }
         }
         .moodle-actionmenu:not([data-enhanced]) {
-            li {line-height:normal;}
+            li {
+                line-height: normal;
+            }
             > .menubar a {
-                color:inherit;
-                display:inline-block;
+                color: inherit;
+                display: inline-block;
                 > img {
-                    display:none;
+                    display: none;
                 }
                 .caret {
                     display: none;
                 }
             }
             > .menu .menu-action-text {
-                display:inline-block;
+                display: inline-block;
             }
         }
     }
     ul.ml {
         list-style: none;
-        margin:1rem 0;
+        margin: 1rem 0;
         ul.ml {
-            margin:0;
+            margin: 0;
         }
     }
     li {
-        line-height:2.2em;
+        line-height: 2.2em;
         > div {
             &:hover {
-                background-color:#fafafa;
+                background-color: @table-bg-hover;
             }
         }
         .tree-icon {
             margin: 2px 6px 0 0;
-            width:12px;
-            vertical-align:inherit;
+            width: 12px;
+            vertical-align: inherit;
         }
         &[data-selected='1'] {
             > div {
-                background-color:#ffffd8;
-                border-top-color: #e1e1e8;
-                border-bottom-color:#f5f5f5;
+                background-color: @state-info-bg;
+                border-top-color: @table-border-color;
+                border-bottom-color: @table-border-color;
             }
             li:first-of-type > div,
             &[data-expandable='0']+li > div {
-                border-top-color:#e1e1e8;
+                border-top-color: @table-border-color;
             }
             &:last-of-type > div {
-                border-bottom-color:#e1e1e8;
+                border-bottom-color: @table-border-color;
             }
         }
 
@@ -801,7 +797,7 @@ span.editinstructions {
 
         &+li > div,
         &:first-child > div {
-            border-top-color:#f5f5f5;
+            border-top-color: @table-border-color;
         }
     }
 
@@ -847,10 +843,10 @@ span.editinstructions {
                 }
             }
             .without-actions {
-                color: #333;
+                color: @text-color;
             }
             .idnumber {
-                color:#a1a1a8;
+                color:@text-color;
                 margin-right:2em;
             }
         }
@@ -886,7 +882,7 @@ span.editinstructions {
             > div,
             > div:hover,
             &[data-selected='1'] > div {
-                background-color:#dfa;
+                background-color: @state-info-bg;
             }
         }
     }
@@ -894,15 +890,15 @@ span.editinstructions {
     #course-listing {
         .listitem {
             .categoryname {
-                display:inline-block;
-                margin-left:1em;
-                color:#a1a1a8;
+                display: inline-block;
+                margin-left: 1em;
+                color: @text-color;
             }
             .coursename {
-                display:inline-block;
+                display: inline-block;
             }
             > div {
-                padding-left:1rem;
+                padding-left: 1rem;
             }
         }
         > .firstpage .listitem:first-child > div .item-actions .action-moveup,
@@ -910,7 +906,7 @@ span.editinstructions {
           display: none;
         }
         .bulk-action-checkbox {
-            margin:-2px 6px 0 0;
+            margin: -2px 6px 0 0;
         }
     }
     #category-listing {
@@ -920,18 +916,18 @@ span.editinstructions {
         .listitem {
             > div {
                 > .ba-checkbox {
-                    width:2.2em;
-                    text-align:center;
-                    margin:-1px 0.5em 0 0;
-                    padding-top:2px;
+                    width: 2.2em;
+                    text-align: center;
+                    margin: -1px 0.5em 0 0;
+                    padding-top: 2px;
                 }
             }
             &.highlight > div > .ba-checkbox {
-                background-color:#dfa;
+                background-color: @state-info-bg;
             }
             &[data-selected='1'] > div > .ba-checkbox {
-                margin:0 0.5em 0 0;
-                padding:0;
+                margin: 0 0.5em 0 0;
+                padding: 0;
                 background-color: inherit;
             }
             &:first-child > div .item-actions .action-moveup,
@@ -941,12 +937,12 @@ span.editinstructions {
         }
         .course-count {
             color: @text-color;
-            margin-right:2rem;
-            min-width:3.5em;
-            display:inline-block;
+            margin-right: 2rem;
+            min-width: 3.5em;
+            display: inline-block;
             .smallicon {
-                width:12px;
-                margin-left:4px;
+                width: 12px;
+                margin-left: 4px;
                 vertical-align: inherit;
             }
         }
@@ -954,58 +950,60 @@ span.editinstructions {
             margin-right: -3px;
         }
         .category-listing > ul > .listitem:first-child {
-            position:relative;
+            position: relative;
         }
         .category-bulk-actions {
             margin: 0 0.5em 0.5em;
-            position:relative;
+            position: relative;
         }
     }
 
     .detail-pair {
-        border-bottom:1px solid #e1e1e8;
-        margin:0 1rem;
+        border-bottom:1px solid @table-border-color;
+        margin: 0 1rem;
         > * {
-            display:inline-block;
-            line-height:2.2rem;
+            display: inline-block;
+            line-height: 2.2rem;
         }
         .pair-key {
-            font-weight:bold;
+            font-weight: bold;
             vertical-align: top;
             span {
                 margin-right: 1rem;
-                display:block;
+                display: block;
             }
         }
         .pair-value select {
-            max-width:100%;
+            max-width: 100%;
         }
     }
 
     .bulk-actions .detail-pair {
         > * {
-            display:block;
-            width:100%;
+            display: block;
+            width: 100%;
         }
     }
 
     .listing-pagination {
-        text-align:center;
+        text-align: center;
         .yui3-button {
-            background-color:#fff;
-            border:0;
-            margin:0.4rem 0.2rem 0.45rem;
-            font-size:10.4px;
+            background-color: @btn-default-bg;
+            color: @btn-default-color;
+            border: 0;
+            margin: .4rem .2rem .45rem;
+            font-size: 10.4px;
             &.active-page {
-                background-color:#e5effd;
+                background-color: @btn-primary-bg;
+                color: @btn-primary-color;
             }
         }
     }
     .listing-pagination-totals {
-        text-align:center;
+        text-align: center;
         &.dimmed {
             .text-muted;
-            margin:0.4rem 1rem 0.45rem;
+            margin: .4rem 1rem .45rem;
         }
     }
     .select-a-category .notifymessage,
@@ -1018,26 +1016,26 @@ span.editinstructions {
     display: none;
 }
 .jsenabled #course-category-listings #course-listing .listitem .drag-handle {
-    display:inline-block;
+    display: inline-block;
     margin: 0 6px 0 0;
-    cursor:pointer;
+    cursor: pointer;
 }
 
 /** Management header styling **/
 .coursecat-management-header {
-    vertical-align:middle;
+    vertical-align: middle;
     h2 {
-        display:inline-block;
-        text-align:left;
+        display: inline-block;
+        text-align: left;
     }
     > div {
-        display:inline-block;
-        float:right;
-        line-height:40px;
+        display: inline-block;
+        float: right;
+        line-height: 40px;
         > div {
-          margin-left:1em;
+          margin-left: 1em;
           margin: 10px 0;
-          display:inline-block;
+          display: inline-block;
         }
     }
     select {
@@ -1049,18 +1047,18 @@ span.editinstructions {
     }
     .view-mode-selector {
         .moodle-actionmenu {
-            white-space:nowrap;
-            display:inline-block;
+            white-space: nowrap;
+            display: inline-block;
         }
         .moodle-actionmenu[data-enhanced].show .menu a {
-            padding-left:1em;
+            padding-left: 1em;
         }
     }
 }
 .course-being-dragged-proxy {
     border: 0;
     color: @link-color;
-    vertical-align:middle;
+    vertical-align: middle;
     padding: 0 0 0 4em;
 }
 .course-being-dragged {

--- a/style/moodle-rtl.css
+++ b/style/moodle-rtl.css
@@ -11041,18 +11041,8 @@ span.editinstructions {
   height: 21px;
 }
 
-/**
- * Course management page
- * Palette
- *
- * Background (reg)         #f5f5f5
- * Background (light        #fafafa
- * Background (highlight)   #dfa
- * Borders                  #e1e1e8
- */
-
 #course-category-listings {
-  background-color: #fff;
+  background-color: transparent;
   margin-bottom: 200px;
   /** Two column layout */
   /** Three column layout */
@@ -11069,7 +11059,7 @@ span.editinstructions {
 
 #course-category-listings > div > div {
   min-height: 300px;
-  border: 1px solid #e1e1e8;
+  border: 1px solid #dddddd;
 }
 
 #course-category-listings > div > div > ul.ml > li:first-child > div {
@@ -11078,14 +11068,15 @@ span.editinstructions {
 
 #course-category-listings h3 {
   margin: 0;
-  padding: 0.4rem 0.6rem 0.3rem;
+  padding: .4rem .6rem .3rem;
   background-color: #f5f5f5;
-  border-bottom: 1px solid #e1e1e8;
+  color: #555555;
+  border-bottom: 1px solid #dddddd;
 }
 
 #course-category-listings h4 {
   margin: 1rem 0 0;
-  padding: 0.6rem 1rem 0.5rem;
+  padding: .6rem 1rem .5rem;
 }
 
 #course-category-listings .moodle-actionmenu {
@@ -11106,7 +11097,7 @@ span.editinstructions {
 
 #course-category-listings .listing-actions {
   text-align: center;
-  padding: 0.4rem 0.3rem 0.3rem;
+  padding: .4rem .3rem .3rem;
   line-height: 2.2em;
 }
 
@@ -11153,7 +11144,7 @@ span.editinstructions {
 }
 
 #course-category-listings li > div:hover {
-  background-color: #fafafa;
+  background-color: #f5f5f5;
 }
 
 #course-category-listings li .tree-icon {
@@ -11163,18 +11154,18 @@ span.editinstructions {
 }
 
 #course-category-listings li[data-selected='1'] > div {
-  background-color: #ffffd8;
-  border-top-color: #e1e1e8;
-  border-bottom-color: #f5f5f5;
+  background-color: #d9edf7;
+  border-top-color: #dddddd;
+  border-bottom-color: #dddddd;
 }
 
 #course-category-listings li[data-selected='1'] li:first-of-type > div,
 #course-category-listings li[data-selected='1'][data-expandable='0'] + li > div {
-  border-top-color: #e1e1e8;
+  border-top-color: #dddddd;
 }
 
 #course-category-listings li[data-selected='1']:last-of-type > div {
-  border-bottom-color: #e1e1e8;
+  border-bottom-color: #dddddd;
 }
 
 #course-category-listings li .tree-icon {
@@ -11211,7 +11202,7 @@ span.editinstructions {
 
 #course-category-listings li + li > div,
 #course-category-listings li:first-child > div {
-  border-top-color: #f5f5f5;
+  border-top-color: #dddddd;
 }
 
 #course-category-listings .item-actions {
@@ -11258,11 +11249,11 @@ span.editinstructions {
 }
 
 #course-category-listings .listitem > div .without-actions {
-  color: #333;
+  color: #555555;
 }
 
 #course-category-listings .listitem > div .idnumber {
-  color: #a1a1a8;
+  color: #555555;
   margin-left: 2em;
 }
 
@@ -11298,13 +11289,13 @@ span.editinstructions {
 #course-category-listings .listitem.highlight > div,
 #course-category-listings .listitem.highlight > div:hover,
 #course-category-listings .listitem.highlight[data-selected='1'] > div {
-  background-color: #dfa;
+  background-color: #d9edf7;
 }
 
 #course-category-listings #course-listing .listitem .categoryname {
   display: inline-block;
   margin-right: 1em;
-  color: #a1a1a8;
+  color: #555555;
 }
 
 #course-category-listings #course-listing .listitem .coursename {
@@ -11336,7 +11327,7 @@ span.editinstructions {
 }
 
 #course-category-listings #category-listing .listitem.highlight > div > .ba-checkbox {
-  background-color: #dfa;
+  background-color: #d9edf7;
 }
 
 #course-category-listings #category-listing .listitem[data-selected='1'] > div > .ba-checkbox {
@@ -11377,7 +11368,7 @@ span.editinstructions {
 }
 
 #course-category-listings .detail-pair {
-  border-bottom: 1px solid #e1e1e8;
+  border-bottom: 1px solid #dddddd;
   margin: 0 1rem;
 }
 
@@ -11410,14 +11401,16 @@ span.editinstructions {
 }
 
 #course-category-listings .listing-pagination .yui3-button {
-  background-color: #fff;
+  background-color: #ffffff;
+  color: #555555;
   border: 0;
-  margin: 0.4rem 0.2rem 0.45rem;
+  margin: .4rem .2rem .45rem;
   font-size: 10.4px;
 }
 
 #course-category-listings .listing-pagination .yui3-button.active-page {
-  background-color: #e5effd;
+  background-color: #2fa4e7;
+  color: #ffffff;
 }
 
 #course-category-listings .listing-pagination-totals {
@@ -11426,7 +11419,7 @@ span.editinstructions {
 
 #course-category-listings .listing-pagination-totals.dimmed {
   color: #999999;
-  margin: 0.4rem 1rem 0.45rem;
+  margin: .4rem 1rem .45rem;
 }
 
 #course-category-listings .select-a-category .notifymessage,

--- a/style/moodle.css
+++ b/style/moodle.css
@@ -9006,17 +9006,8 @@ span.editinstructions {
   width: 21px;
   height: 21px;
 }
-/**
- * Course management page
- * Palette
- *
- * Background (reg)         #f5f5f5
- * Background (light        #fafafa
- * Background (highlight)   #dfa
- * Borders                  #e1e1e8
- */
 #course-category-listings {
-  background-color: #fff;
+  background-color: transparent;
   margin-bottom: 200px;
   /** Two column layout */
   /** Three column layout */
@@ -9030,20 +9021,21 @@ span.editinstructions {
 }
 #course-category-listings > div > div {
   min-height: 300px;
-  border: 1px solid #e1e1e8;
+  border: 1px solid #dddddd;
 }
 #course-category-listings > div > div > ul.ml > li:first-child > div {
   border-top: 0;
 }
 #course-category-listings h3 {
   margin: 0;
-  padding: 0.4rem 0.6rem 0.3rem;
+  padding: .4rem .6rem .3rem;
   background-color: #f5f5f5;
-  border-bottom: 1px solid #e1e1e8;
+  color: #555555;
+  border-bottom: 1px solid #dddddd;
 }
 #course-category-listings h4 {
   margin: 1rem 0 0;
-  padding: 0.6rem 1rem 0.5rem;
+  padding: .6rem 1rem .5rem;
 }
 #course-category-listings .moodle-actionmenu {
   white-space: nowrap;
@@ -9059,7 +9051,7 @@ span.editinstructions {
 }
 #course-category-listings .listing-actions {
   text-align: center;
-  padding: 0.4rem 0.3rem 0.3rem;
+  padding: .4rem .3rem .3rem;
   line-height: 2.2em;
 }
 #course-category-listings .listing-actions > .moodle-actionmenu {
@@ -9095,7 +9087,7 @@ span.editinstructions {
   line-height: 2.2em;
 }
 #course-category-listings li > div:hover {
-  background-color: #fafafa;
+  background-color: #f5f5f5;
 }
 #course-category-listings li .tree-icon {
   margin: 2px 6px 0 0;
@@ -9103,16 +9095,16 @@ span.editinstructions {
   vertical-align: inherit;
 }
 #course-category-listings li[data-selected='1'] > div {
-  background-color: #ffffd8;
-  border-top-color: #e1e1e8;
-  border-bottom-color: #f5f5f5;
+  background-color: #d9edf7;
+  border-top-color: #dddddd;
+  border-bottom-color: #dddddd;
 }
 #course-category-listings li[data-selected='1'] li:first-of-type > div,
 #course-category-listings li[data-selected='1'][data-expandable='0'] + li > div {
-  border-top-color: #e1e1e8;
+  border-top-color: #dddddd;
 }
 #course-category-listings li[data-selected='1']:last-of-type > div {
-  border-bottom-color: #e1e1e8;
+  border-bottom-color: #dddddd;
 }
 #course-category-listings li .tree-icon {
   margin-left: 0;
@@ -9140,7 +9132,7 @@ span.editinstructions {
 }
 #course-category-listings li + li > div,
 #course-category-listings li:first-child > div {
-  border-top-color: #f5f5f5;
+  border-top-color: #dddddd;
 }
 #course-category-listings .item-actions {
   margin-right: 1em;
@@ -9177,10 +9169,10 @@ span.editinstructions {
   display: inline;
 }
 #course-category-listings .listitem > div .without-actions {
-  color: #333;
+  color: #555555;
 }
 #course-category-listings .listitem > div .idnumber {
-  color: #a1a1a8;
+  color: #555555;
   margin-right: 2em;
 }
 #course-category-listings .listitem[data-visible="0"] {
@@ -9208,12 +9200,12 @@ span.editinstructions {
 #course-category-listings .listitem.highlight > div,
 #course-category-listings .listitem.highlight > div:hover,
 #course-category-listings .listitem.highlight[data-selected='1'] > div {
-  background-color: #dfa;
+  background-color: #d9edf7;
 }
 #course-category-listings #course-listing .listitem .categoryname {
   display: inline-block;
   margin-left: 1em;
-  color: #a1a1a8;
+  color: #555555;
 }
 #course-category-listings #course-listing .listitem .coursename {
   display: inline-block;
@@ -9238,7 +9230,7 @@ span.editinstructions {
   padding-top: 2px;
 }
 #course-category-listings #category-listing .listitem.highlight > div > .ba-checkbox {
-  background-color: #dfa;
+  background-color: #d9edf7;
 }
 #course-category-listings #category-listing .listitem[data-selected='1'] > div > .ba-checkbox {
   margin: 0 0.5em 0 0;
@@ -9271,7 +9263,7 @@ span.editinstructions {
   position: relative;
 }
 #course-category-listings .detail-pair {
-  border-bottom: 1px solid #e1e1e8;
+  border-bottom: 1px solid #dddddd;
   margin: 0 1rem;
 }
 #course-category-listings .detail-pair > * {
@@ -9297,20 +9289,22 @@ span.editinstructions {
   text-align: center;
 }
 #course-category-listings .listing-pagination .yui3-button {
-  background-color: #fff;
+  background-color: #ffffff;
+  color: #555555;
   border: 0;
-  margin: 0.4rem 0.2rem 0.45rem;
+  margin: .4rem .2rem .45rem;
   font-size: 10.4px;
 }
 #course-category-listings .listing-pagination .yui3-button.active-page {
-  background-color: #e5effd;
+  background-color: #2fa4e7;
+  color: #ffffff;
 }
 #course-category-listings .listing-pagination-totals {
   text-align: center;
 }
 #course-category-listings .listing-pagination-totals.dimmed {
   color: #999999;
-  margin: 0.4rem 1rem 0.45rem;
+  margin: .4rem 1rem .45rem;
 }
 #course-category-listings .select-a-category .notifymessage,
 #course-category-listings .select-a-category .alert {


### PR DESCRIPTION
The new course management interface added lots of hardcoded
colors. Testing with Darkly and Amelia mostly, I switched them
for table color variables.

The headings looked a bit panel-y so used panel variables for
those.

Helps with #206
