### PR TITLE
Add font weight and italic options for brand font

### DIFF
--- a/lang/en/theme_bootstrap.php
+++ b/lang/en/theme_bootstrap.php
@@ -23,6 +23,10 @@
 
 $string['brandfont'] = 'Logotype Font';
 $string['brandfontdesc'] = 'The name of a Google Font to use for the site name in the navbar';
+$string['brandfontitalic'] = 'Logotype Italics';
+$string['brandfontitalicdesc'] = 'Use the italic version of the font, check italic is available at the selected weight';
+$string['brandfontweight'] = 'Logotype Weight';
+$string['brandfontweightdesc'] = 'Weight of the font, 400 is normal, 700 bold, double check what weights the font supports';
 $string['customcss'] = 'Custom CSS';
 $string['customcssdesc'] = 'Whatever CSS rules you add to this textarea will be reflected in every page, making for easier customization of this theme.';
 $string['deletecss'] = 'Delete Unneeded CSS';
@@ -31,6 +35,15 @@ $string['fluidwidth'] = 'Fluid width theme';
 $string['fluidwidthdesc'] = 'Enable this option to allow using your full screen';
 $string['fonticons'] = 'Use Icon Font';
 $string['fonticonsdesc'] = 'Enable this option to use the Glyphicon Icon Font';
+$string['fontweight100'] = '100 (thin)';
+$string['fontweight200'] = '200';
+$string['fontweight300'] = '300 (light)';
+$string['fontweight400'] = '400 (normal)';
+$string['fontweight500'] = '500';
+$string['fontweight600'] = '600';
+$string['fontweight700'] = '700 (bold)';
+$string['fontweight800'] = '800';
+$string['fontweight900'] = '900 (ultra-bold)';
 $string['footerwidget'] = 'Footer Widget #{$a}';
 $string['footerwidgetdesc'] = 'All footer widgets have the same description';
 $string['inversenavbar'] = 'Inverse Navbar';
@@ -39,6 +52,7 @@ $string['pluginname'] = 'Bootstrap 3';
 $string['reader'] = 'Reader';
 $string['region-side-post'] = 'Right';
 $string['region-side-pre'] = 'Left';
+
 
 $string['choosereadme'] = '
 <div class="clearfix"><div class="theme_screenshot"><h2>Bootstrap Base</h2>

--- a/lib.php
+++ b/lib.php
@@ -81,9 +81,11 @@ function theme_bootstrap_brand_font_css($settings) {
     if ($fontname === '') {
         return '';
     }
+    $fontweight = $settings['brandfontweight'];
     return ".navbar-default .navbar-brand,
             .navbar-inverse .navbar-brand {
-                font-family: $fontname;
+                font-family: $fontname, serif;
+                font-weight: $fontweight;
             }";
 }
 
@@ -112,20 +114,26 @@ function theme_bootstrap_html_for_settings($PAGE) {
         $html->containerclass = 'container';
     }
 
-    $html->brandfontlink = theme_bootstrap_brand_font_link($settings->brandfont);
+    $html->brandfontlink = theme_bootstrap_brand_font_link($settings);
 
     return $html;
 }
 
-function theme_bootstrap_brand_font_link($fontname) {
+function theme_bootstrap_brand_font_link($settings) {
     global $SITE;
+    $fontname = $settings->brandfont;
     if ($fontname === '') {
         return '';
     }
     $fontname = urlencode($fontname);
-    $nameletters = count_chars($SITE->shortname, 3);
+    $text = urlencode(str_replace(' ', '', $SITE->shortname));
+    $fontweight = $settings->brandfontweight;
+    $fontitalic = '';
+    if ($settings->brandfontitalic == true) {
+        $fontitalic = 'italic';
+    }
     return '<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family='
-            .$fontname.'&text='.$nameletters.'">';
+            .$fontname.':'.$fontweight.$fontitalic.'&amp;text='.$text.'">';
 }
 
 function bootstrap_grid($hassidepre, $hassidepost) {

--- a/settings.php
+++ b/settings.php
@@ -30,10 +30,23 @@ require_once(__DIR__ . "/simple_theme_settings.class.php");
 
 if ($ADMIN->fulltree) {
     $simplesettings = new simple_theme_settings($settings, 'theme_bootstrap');
+
     $simplesettings->add_checkbox('fluidwidth');
+
     $simplesettings->add_checkbox('fonticons');
+
     $simplesettings->add_checkbox('inversenavbar');
+
     $simplesettings->add_checkbox('deletecss');
+
     $simplesettings->add_text('brandfont');
+
+    foreach (range(100, 900, 100) as $weight) {
+        $fontweights[$weight] = get_string("fontweight$weight", 'theme_bootstrap');
+    }
+    $simplesettings->add_select('brandfontweight', 400, $fontweights);
+
+    $simplesettings->add_checkbox('brandfontitalic');
+
     $simplesettings->add_textarea('customcss');
 }


### PR DESCRIPTION
Lets you choose from some of the other weights of font available,
and turn italics on and off.

Ideally you should only do this if the font actually has these
weights and italics, or you might end up with the page default
font, or an artifically slanted or bolded version.

Note that due to the way Google Fonts names these fonts they can
clash with the other weights of the same font imported separately
e.g. if you import a very heavy weight of Open Sans or Lato which
you also use in the rest of the page, you might see certain letters
(those used in your site shortname) using the heavier weights.

One of my favourites so far is Open Sans, italic, at 800 weight.
And a 0.2 alpha drop shadow added via the CSS comment box seems
to help too.
