### PR TITLE
tighten CSS on form item min-width

### DIFF
--- a/less/moodle/forms.less
+++ b/less/moodle/forms.less
@@ -217,14 +217,14 @@
     .form-buttons .form-submit {
         margin-left: -5px;
     }
-    .form-item .form-setting input[type="text"],
-    .form-item .form-setting input[type="password"],
-    .form-item .form-setting select,
-    .mform .fcontainer .fitem .felement input[type="text"],
-    .mform .fcontainer .fitem .felement input[type="password"],
-    .mform .fcontainer .fitem .felement select {
-        width: auto;
-        min-width: 480px;
+    .form-item .form-setting,
+    .mform .fcontainer .fitem .felement {
+        > input[type="text"],
+        > input[type="password"],
+        > select {
+            width: auto;
+            min-width: 480px;
+        }
     }
     #page-mod-quiz-mod #id_reviewoptionshdr .fitem.fitem_fgroup {
         font-size: @font-size-small;

--- a/style/moodle-rtl.css
+++ b/style/moodle-rtl.css
@@ -7062,8 +7062,8 @@ button.close {
 .mform .fcontainer .fitem:after,
 .mform fieldset .fitem:before,
 .mform fieldset .fitem:after,
-.mform fieldset.hidden:last-child:before,
-.mform fieldset.hidden:last-child:after,
+.mform fieldset.hidden:before,
+.mform fieldset.hidden:after,
 .form-item:before,
 .form-item:after {
   content: " ";
@@ -7091,7 +7091,7 @@ button.close {
 .path-backup .mform .grouped_settings .fitem:after,
 .mform .fcontainer .fitem:after,
 .mform fieldset .fitem:after,
-.mform fieldset.hidden:last-child:after,
+.mform fieldset.hidden:after,
 .form-item:after {
   clear: both;
 }
@@ -7279,128 +7279,6 @@ button.close {
   }
 }
 
-<<<<<<< HEAD
-=======
-.clearfix:before,
-.clearfix:after,
-.container:before,
-.container:after,
-.container-fluid:before,
-.container-fluid:after,
-.row:before,
-.row:after,
-.form-horizontal .form-group:before,
-.form-horizontal .form-group:after,
-.btn-toolbar:before,
-.btn-toolbar:after,
-.btn-group-vertical > .btn-group:before,
-.btn-group-vertical > .btn-group:after,
-.nav:before,
-.nav:after,
-.navbar:before,
-.navbar:after,
-.navbar-header:before,
-.navbar-header:after,
-.navbar-collapse:before,
-.navbar-collapse:after,
-.pager:before,
-.pager:after,
-.panel-body:before,
-.panel-body:after,
-.modal-footer:before,
-.modal-footer:after,
-.box.message .contactselector form#usergroupform fieldset:before,
-.box.message .contactselector form#usergroupform fieldset:after,
-.box.message .messagearea .messagehistory .messagehistory .mdl-left:before,
-.box.message .messagearea .messagehistory .messagehistory .mdl-left:after,
-.userprofile .userprofilebox:before,
-.userprofile .userprofilebox:after,
-.path-backup .mform .grouped_settings:before,
-.path-backup .mform .grouped_settings:after,
-.path-backup .mform .grouped_settings .fitem:before,
-.path-backup .mform .grouped_settings .fitem:after,
-.mform .fcontainer .fitem:before,
-.mform .fcontainer .fitem:after,
-.mform fieldset .fitem:before,
-.mform fieldset .fitem:after,
-.mform fieldset.hidden:before,
-.mform fieldset.hidden:after,
-.form-item:before,
-.form-item:after {
-  content: " ";
-  display: table;
-}
-
-.clearfix:after,
-.container:after,
-.container-fluid:after,
-.row:after,
-.form-horizontal .form-group:after,
-.btn-toolbar:after,
-.btn-group-vertical > .btn-group:after,
-.nav:after,
-.navbar:after,
-.navbar-header:after,
-.navbar-collapse:after,
-.pager:after,
-.panel-body:after,
-.modal-footer:after,
-.box.message .contactselector form#usergroupform fieldset:after,
-.box.message .messagearea .messagehistory .messagehistory .mdl-left:after,
-.userprofile .userprofilebox:after,
-.path-backup .mform .grouped_settings:after,
-.path-backup .mform .grouped_settings .fitem:after,
-.mform .fcontainer .fitem:after,
-.mform fieldset .fitem:after,
-.mform fieldset.hidden:after,
-.form-item:after {
-  clear: both;
-}
-
-.center-block {
-  display: block;
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.pull-right {
-  float: left !important;
-}
-
-.pull-left {
-  float: right !important;
-}
-
-.hide {
-  display: none !important;
-}
-
-.show {
-  display: block !important;
-}
-
-.invisible {
-  visibility: hidden;
-}
-
-.text-hide {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0;
-}
-
-.hidden {
-  display: none !important;
-  visibility: hidden !important;
-}
-
-.affix {
-  position: fixed;
-}
-
->>>>>>> d83ddc3fd4d8487492f1fcfe396e411cfccc1e5d
 /**
  * bootstrapoverride.less
  *
@@ -16722,12 +16600,12 @@ textarea.form-item .form-setting input[type="password"] {
     margin-right: -5px;
   }
 
-  .form-item .form-setting input[type="text"],
-  .form-item .form-setting input[type="password"],
-  .form-item .form-setting select,
-  .mform .fcontainer .fitem .felement input[type="text"],
-  .mform .fcontainer .fitem .felement input[type="password"],
-  .mform .fcontainer .fitem .felement select {
+  .form-item .form-setting > input[type="text"],
+  .mform .fcontainer .fitem .felement > input[type="text"],
+  .form-item .form-setting > input[type="password"],
+  .mform .fcontainer .fitem .felement > input[type="password"],
+  .form-item .form-setting > select,
+  .mform .fcontainer .fitem .felement > select {
     width: auto;
     min-width: 480px;
   }

--- a/style/moodle.css
+++ b/style/moodle.css
@@ -2405,8 +2405,8 @@ input[type="button"].btn-block {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('[[font:theme|glyphicons-halflings-regular.eot');
-  src: url('[[font:theme|glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]');
+  src: url('[[font:theme|glyphicons-halflings-regular.eot]]?#iefix') format('embedded-opentype'), url('[[font:theme|glyphicons-halflings-regular.woff]]') format('woff'), url('[[font:theme|glyphicons-halflings-regular.ttf]]') format('truetype'), url('[[font:theme|glyphicons-halflings-regular.svg]]#glyphicons_halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -13646,12 +13646,12 @@ textarea.form-item .form-setting input[type="password"] {
   .form-buttons .form-submit {
     margin-left: -5px;
   }
-  .form-item .form-setting input[type="text"],
-  .form-item .form-setting input[type="password"],
-  .form-item .form-setting select,
-  .mform .fcontainer .fitem .felement input[type="text"],
-  .mform .fcontainer .fitem .felement input[type="password"],
-  .mform .fcontainer .fitem .felement select {
+  .form-item .form-setting > input[type="text"],
+  .mform .fcontainer .fitem .felement > input[type="text"],
+  .form-item .form-setting > input[type="password"],
+  .mform .fcontainer .fitem .felement > input[type="password"],
+  .form-item .form-setting > select,
+  .mform .fcontainer .fitem .felement > select {
     width: auto;
     min-width: 480px;
   }


### PR DESCRIPTION
We set a min-width on form fields so they line up neatly,
but the rule was wide enough to hit some other, more specialised
form items e.g. the pair of text fields within a table used to
specify device detection regexes in the the theme settings

Might need to keep an eye out for places this needs to be widened
again, but a quick check shows it mostly working.

closes #238
