### PR TITLE
Fix current section indenting.

### DIFF
--- a/renderers.php
+++ b/renderers.php
@@ -27,6 +27,7 @@ require_once('renderers/core_renderer.php');
 require_once('renderers/maintenance_renderer.php');
 require_once('renderers/admin_renderer.php');
 require_once('renderers/course_renderer.php');
+require_once('renderers/course_format_renderer.php');
 require_once('renderers/files_renderer.php');
 require_once('renderers/block_settings_renderer.php');
 require_once('renderers/enrol_renderer.php');

--- a/renderers/course_format_renderer.php
+++ b/renderers/course_format_renderer.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of The Bootstrap 3 Moodle theme
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Renderers to align Moodle's HTML with that expected by Bootstrap
+ *
+ * @package    theme
+ * @subpackage bootstrap
+ * @copyright  &copy; 2014-onwards G J Barnard.
+ * @author     G J Barnard - gjbarnard at gmail dot com and {@link http://moodle.org/user/profile.php?id=442195}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+include_once($CFG->dirroot . "/course/format/topics/renderer.php");
+class theme_bootstrap_format_topics_renderer extends format_topics_renderer {
+    /**
+     * Generate the content to displayed on the left part of a section
+     * before course modules are included
+     *
+     * @param stdClass $section The course_section entry from DB
+     * @param stdClass $course The course entry from DB
+     * @param bool $onsectionpage true if being printed on a section page
+     * @return string HTML to output.
+     */
+    protected function section_left_content($section, $course, $onsectionpage) {
+        $o = $this->output->spacer();
+
+        if ($section->section != 0) {
+            // Only in the non-general sections.
+            if (course_get_format($course)->is_section_current($section)) {
+                $o .= get_accesshide(get_string('currentsection', 'format_'.$course->format));
+            }
+        }
+
+        return $o;
+    }
+}
+
+include_once($CFG->dirroot . "/course/format/weeks/renderer.php");
+class theme_bootstrap_format_weeks_renderer extends format_weeks_renderer {
+    /**
+     * Generate the content to displayed on the left part of a section
+     * before course modules are included
+     *
+     * @param stdClass $section The course_section entry from DB
+     * @param stdClass $course The course entry from DB
+     * @param bool $onsectionpage true if being printed on a section page
+     * @return string HTML to output.
+     */
+    protected function section_left_content($section, $course, $onsectionpage) {
+        $o = $this->output->spacer();
+
+        if ($section->section != 0) {
+            // Only in the non-general sections.
+            if (course_get_format($course)->is_section_current($section)) {
+                $o .= get_accesshide(get_string('currentsection', 'format_'.$course->format));
+            }
+        }
+
+        return $o;
+    }
+}


### PR DESCRIPTION
Fixes current section indenting:

![2014-04-08 11_40_35-course_ document](https://cloud.githubusercontent.com/assets/1058419/2642702/7caf7c82-bf0d-11e3-9f01-2dd3af8ca6d1.png)

to:

![2014-04-08 11_54_37-course_ document](https://cloud.githubusercontent.com/assets/1058419/2642707/891f8fac-bf0d-11e3-9967-4b6ac474a0ee.png)

My contributed formats already do this!  I looked for a core patch possibility but could not justify as B2.3.2 themes not affected.
