### PR TITLE
Add option to show new messages only.

### DIFF
--- a/lang/en/theme_bootstrap.php
+++ b/lang/en/theme_bootstrap.php
@@ -47,11 +47,13 @@ $string['fontweight900'] = '900 (ultra-bold)';
 $string['footerwidget'] = 'Footer Widget #{$a}';
 $string['footerwidgetdesc'] = 'All footer widgets have the same description';
 $string['inversenavbar'] = 'Inverse Navbar';
-$string['inversenavbardesc'] = 'Enable this option to use the inverted color scheme for the navbar';
+$string['inversenavbardesc'] = 'Enable this option to use the inverted colour scheme for the navbar';
 $string['pluginname'] = 'Bootstrap 3';
 $string['reader'] = 'Reader';
 $string['region-side-post'] = 'Right';
 $string['region-side-pre'] = 'Left';
+$string['showoldmessages'] = 'Show old messages';
+$string['showoldmessagesdesc'] = 'Show old messages on the message menu';
 
 
 $string['choosereadme'] = '

--- a/settings.php
+++ b/settings.php
@@ -37,6 +37,8 @@ if ($ADMIN->fulltree) {
 
     $simplesettings->add_checkbox('inversenavbar');
 
+    $simplesettings->add_checkbox('showoldmessages');
+
     $simplesettings->add_checkbox('deletecss');
 
     $simplesettings->add_text('brandfont');

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2014032100;
+$plugin->version   = 2014032101;
 $plugin->requires  = 2013110500;
 $plugin->maturity  = MATURITY_BETA;
 $plugin->release   = 2014022000;


### PR DESCRIPTION
Hi Bas,

This has been spawned from Elegance on the iMoot site showing old messages when you log in which was driving me nuts!

This is the most efficient solution, but the first attempt is here: https://github.com/gjb2048/theme_bootstrap/tree/master_messages - if you wanted an alternative :)

Both branches also solve a logic flaw in the count of the messages when (!$message->from) is true. And... display the right word for 'message' / 'messages' given the number.

Cheers,

Gareth
