### PR TITLE
clean renderers with moodle code checker

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -66,8 +66,8 @@ class theme_bootstrap_core_renderer extends core_renderer {
     }
 
     public function custom_menu($custommenuitems = '') {
-    // The custom menu is always shown, even if no menu items
-    // are configured in the global theme settings page.
+        // The custom menu is always shown, even if no menu items
+        // are configured in the global theme settings page.
         global $CFG;
 
         if (!empty($CFG->custommenuitems)) {

--- a/renderers/course_format_renderer.php
+++ b/renderers/course_format_renderer.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-include_once($CFG->dirroot . "/course/format/topics/renderer.php");
+require_once($CFG->dirroot . "/course/format/topics/renderer.php");
 class theme_bootstrap_format_topics_renderer extends format_topics_renderer {
     /**
      * Generate the content to displayed on the left part of a section
@@ -51,7 +51,7 @@ class theme_bootstrap_format_topics_renderer extends format_topics_renderer {
     }
 }
 
-include_once($CFG->dirroot . "/course/format/weeks/renderer.php");
+require_once($CFG->dirroot . "/course/format/weeks/renderer.php");
 class theme_bootstrap_format_weeks_renderer extends format_weeks_renderer {
     /**
      * Generate the content to displayed on the left part of a section

--- a/renderers/course_management.php
+++ b/renderers/course_management.php
@@ -35,7 +35,7 @@ class theme_bootstrap_core_course_management_renderer extends core_course_manage
      * @param string $class A class to give this grid.
      * @return string
      */
-     public function grid_start($id = null, $class = null) {
+    public function grid_start($id = null, $class = null) {
         $gridclass = 'grid-row-r row';
         if (is_null($class)) {
             $class = $gridclass;
@@ -48,7 +48,7 @@ class theme_bootstrap_core_course_management_renderer extends core_course_manage
         }
         return html_writer::start_div($class, $attributes);
     }
-    
+
     /**
      * Opens a grid column
      *
@@ -78,9 +78,9 @@ class theme_bootstrap_core_course_management_renderer extends core_course_manage
             }
         }
         if ($maxsize > 1) {
-            $yuigridclass =  "grid-col-{$size}-{$maxsize} grid-col";
+            $yuigridclass = "grid-col-{$size}-{$maxsize} grid-col";
         } else {
-            $yuigridclass =  "grid-col-1 grid-col";
+            $yuigridclass = "grid-col-1 grid-col";
         }
 
         if (is_null($class)) {

--- a/renderers/course_renderer.php
+++ b/renderers/course_renderer.php
@@ -53,37 +53,38 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
 
         // Course name.
         $coursename = $chelper->get_course_formatted_name($course);
-        $content .=  html_writer::link(new moodle_url('/course/view.php', array('id' => $course->id)),
+        $content .= html_writer::link(new moodle_url('/course/view.php', array('id' => $course->id)),
             $coursename, array('class' => $course->visible ? '' : 'dimmed'));
-        
 
         // If we display course in collapsed form but the course has summary or course contacts, display the link to the info page.
         if ($chelper->get_show_courses() < self::COURSECAT_SHOW_COURSES_EXPANDED) {
             if ($course->has_summary() || $course->has_course_contacts() || $course->has_course_overviewfiles()) {
                 $url = new moodle_url('/course/info.php', array('id' => $course->id));
-                $arrow = html_writer::tag('span', '', array('class'=>'glyphicon glyphicon-info-sign'));
-                $content .= html_writer::link('#coursecollapse' . $course->id , '&nbsp;' . $arrow, array('data-toggle' => 'collapse', 'data-parent' => '#frontpage-category-combo'));
+                $arrow = html_writer::tag('span', '', array('class' => 'glyphicon glyphicon-info-sign'));
+                $content .= html_writer::link('#coursecollapse' . $course->id , '&nbsp;' . $arrow,
+                    array('data-toggle' => 'collapse', 'data-parent' => '#frontpage-category-combo'));
             }
         }
-        
-        // print enrolmenticons
+
+        // Print enrolmenticons.
         if ($icons = enrol_get_course_info_icons($course)) {
             $content .= html_writer::start_tag('div', array('class' => 'enrolmenticons'));
-            foreach ($icons as $pix_icon) {
-                $content .= $this->render($pix_icon);
+            foreach ($icons as $pixicon) {
+                $content .= $this->render($pixicon);
             }
-            $content .= html_writer::end_tag('div'); // .enrolmenticons
+            $content .= html_writer::end_tag('div'); // End .enrolmenticons.
         }
 
         $content .= html_writer::end_tag('div'); // End .panel-heading.
 
         if ($chelper->get_show_courses() < self::COURSECAT_SHOW_COURSES_EXPANDED) {
-            $content .= html_writer::start_tag('div', array('id' => 'coursecollapse' . $course->id, 'class' => 'panel-collapse collapse'));
+            $content .= html_writer::start_tag('div', array('id' => 'coursecollapse' . $course->id,
+                'class' => 'panel-collapse collapse'));
         }
-        
+
         $content .= html_writer::start_tag('div', array('class' => 'panel-body'));
-        
-        // This gets the course image or files
+
+        // This gets the course image or files.
         $content .= $this->coursecat_coursebox_content($chelper, $course);
 
         if ($chelper->get_show_courses() >= self::COURSECAT_SHOW_COURSES_EXPANDED) {
@@ -92,7 +93,7 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
                 $icondirection = 'right';
             }
             if (is_enrolled(context_course::instance($course->id))) {
-                $arrow = html_writer::tag('span','', array('class' => ' glyphicon glyphicon-arrow-'.$icondirection));
+                $arrow = html_writer::tag('span', '', array('class' => ' glyphicon glyphicon-arrow-'.$icondirection));
                 $btn = html_writer::tag('span', get_string('course') . ' ' . $arrow, array('class' => 'coursequicklink'));
                 $content .= html_writer::link(new moodle_url('/course/view.php',
                     array('id' => $course->id)), $btn, array('class' => 'coursebtn btn btn-info btn-sm pull-right'));
@@ -112,16 +113,13 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
 
     protected function coursecat_coursebox_content(coursecat_helper $chelper, $course) {
         global $CFG;
-        // if ($chelper->get_show_courses() < self::COURSECAT_SHOW_COURSES_EXPANDED) {
-        //     return '';
-        // }
         if ($course instanceof stdClass) {
             require_once($CFG->libdir. '/coursecatlib.php');
             $course = new course_in_list($course);
         }
         $content = '';
 
-        // display course overview files
+        // Display course overview files.
         $contentimages = $contentfiles = '';
         foreach ($course->get_course_overviewfiles() as $file) {
             $isimage = $file->is_valid_image();
@@ -129,7 +127,7 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
                     '/'. $file->get_contextid(). '/'. $file->get_component(). '/'.
                     $file->get_filearea(). $file->get_filepath(). $file->get_filename(), !$isimage);
             if ($isimage) {
-                $contentimages .= html_writer::empty_tag('img', array('src' => $url, 'alt' => 'Course Image '. $course->fullname, 
+                $contentimages .= html_writer::empty_tag('img', array('src' => $url, 'alt' => 'Course Image '. $course->fullname,
                     'class' => 'courseimage'));
             } else {
                 $image = $this->output->pix_icon(file_file_icon($file, 24), $file->get_filename(), 'moodle');
@@ -142,12 +140,12 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
         }
         $content .= $contentimages. $contentfiles;
 
-        // display course summary
+        // Display course summary.
         if ($course->has_summary()) {
             $content .= $course->summary;
         }
 
-        // display course contacts. See course_in_list::get_course_contacts()
+        // Display course contacts. See course_in_list::get_course_contacts().
         if ($course->has_course_contacts()) {
             $content .= html_writer::start_tag('ul', array('class' => 'teachers'));
             foreach ($course->get_course_contacts() as $userid => $coursecontact) {
@@ -157,10 +155,10 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
                             $coursecontact['username']);
                 $content .= html_writer::tag('li', $name);
             }
-            $content .= html_writer::end_tag('ul'); // .teachers
+            $content .= html_writer::end_tag('ul'); // End .teachers.
         }
 
-        // display course category if necessary (for example in search results)
+        // Display course category if necessary (for example in search results).
         if ($chelper->get_show_courses() == self::COURSECAT_SHOW_COURSES_EXPANDED_WITH_CAT) {
             require_once($CFG->libdir. '/coursecatlib.php');
             if ($cat = coursecat::get($course->category, IGNORE_MISSING)) {
@@ -168,11 +166,11 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
                 $content .= get_string('category').': '.
                         html_writer::link(new moodle_url('/course/index.php', array('categoryid' => $cat->id)),
                                 $cat->get_formatted_name(), array('class' => $cat->visible ? '' : 'dimmed'));
-                $content .= html_writer::end_tag('div'); // .coursecat
+                $content .= html_writer::end_tag('div'); // End .coursecat.
             }
         }
 
-        $content .= html_writer::tag('div', '', array('class' => 'boxfooter')); // .coursecat
+        $content .= html_writer::tag('div', '', array('class' => 'boxfooter')); // End .coursecat.
 
         return $content;
     }

--- a/renderers/enrol_renderer.php
+++ b/renderers/enrol_renderer.php
@@ -32,7 +32,7 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
 
         $table->initialise_javascript();
 
-        // Added for the Bootstrap theme. Make this table responsive
+        // Added for the Bootstrap theme. Make this table responsive.
         $table->attributes['class'] .= ' table table-responsive';
 
         $buttons = $table->get_manual_enrol_buttons();
@@ -56,7 +56,8 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
         // Check if the table has any bulk operations. If it does we want to wrap the table in a
         // form so that we can capture and perform any required bulk operations.
         if ($table->has_bulk_user_enrolment_operations()) {
-            $content .= html_writer::start_tag('form', array('action' => new moodle_url('/enrol/bulkchange.php'), 'method' => 'post'));
+            $content .= html_writer::start_tag('form', array('action' => new moodle_url('/enrol/bulkchange.php'),
+                                               'method' => 'post'));
             foreach ($table->get_combined_url_params() as $key => $value) {
                 if ($key == 'action') {
                     continue;
@@ -78,7 +79,7 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
 
             $content .= html_writer::end_tag('form');
         } else {
-            // Added for the Bootstrap theme, a no-overflow wrapper
+            // Added for the Bootstrap theme, a no-overflow wrapper.
             $content .= html_writer::start_tag('div', array('class' => 'no-overflow'));
             $content .= html_writer::table($table);
             $content .= html_writer::end_tag('div');
@@ -94,16 +95,18 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
         $iconenroladd    = $this->output->pix_url('t/enroladd');
         $iconenrolremove = $this->output->pix_url('t/delete');
 
-        // get list of roles
+        // Get list of roles.
         $rolesoutput = '';
-        foreach ($roles as $roleid=>$role) {
+        foreach ($roles as $roleid => $role) {
             if ($canassign and (is_siteadmin() or isset($assignableroles[$roleid])) and !$role['unchangeable']) {
                 $strunassign = get_string('unassignarole', 'role', $role['text']);
-                $icon = html_writer::empty_tag('img', array('alt'=>$strunassign, 'src'=>$iconenrolremove));
-                $url = new moodle_url($pageurl, array('action'=>'unassign', 'roleid'=>$roleid, 'user'=>$userid));
-                $rolesoutput .= html_writer::tag('div', $role['text'] . html_writer::link($url, $icon, array('class'=>'unassignrolelink', 'rel'=>$roleid, 'title'=>$strunassign)), array('class'=>'role role_'.$roleid));
+                $icon = html_writer::empty_tag('img', array('alt' => $strunassign, 'src' => $iconenrolremove));
+                $url = new moodle_url($pageurl, array('action' => 'unassign', 'roleid' => $roleid, 'user' => $userid));
+                $rolesoutput .= html_writer::tag('div', $role['text'] . html_writer::link($url, $icon,
+                    array('class' => 'unassignrolelink', 'rel' => $roleid, 'title' => $strunassign)),
+                    array('class' => 'role role_'.$roleid));
             } else {
-                $rolesoutput .= html_writer::tag('div', $role['text'], array('class'=>'role unchangeable', 'rel'=>$roleid));
+                $rolesoutput .= html_writer::tag('div', $role['text'], array('class' => 'role unchangeable', 'rel' => $roleid));
             }
         }
         $output = '';
@@ -117,12 +120,15 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
                 }
             }
             if (!$hasallroles) {
-                $url = new moodle_url($pageurl, array('action'=>'assign', 'user'=>$userid));
-                $icon = html_writer::tag('label', get_string('assignroles', 'role'), array('alt'=>get_string('assignroles', 'role'), 'class' => 'label label-primary'));
-                $output = html_writer::tag('div', html_writer::link($url, $icon, array('class'=>'assignrolelink', 'title'=>get_string('assignroles', 'role'))), array('class'=>'addrole'));
+                $url = new moodle_url($pageurl, array('action' => 'assign', 'user' => $userid));
+                $icon = html_writer::tag('label', get_string('assignroles', 'role'),
+                    array('alt' => get_string('assignroles', 'role'), 'class' => 'label label-primary'));
+                $output = html_writer::tag('div', html_writer::link($url, $icon,
+                    array('class' => 'assignrolelink', 'title' => get_string('assignroles', 'role'))),
+                    array('class' => 'addrole'));
             }
         }
-        $output .= html_writer::tag('div', $rolesoutput, array('class'=>'roles'));
+        $output .= html_writer::tag('div', $rolesoutput, array('class' => 'roles'));
         return $output;
     }
 
@@ -133,23 +139,26 @@ class theme_bootstrap_core_enrol_renderer extends core_enrol_renderer {
         $straddgroup = get_string('addgroup', 'group');
 
         $groupoutput = '';
-        foreach($groups as $groupid=>$name) {
+        foreach ($groups as $groupid => $name) {
             if ($canmanagegroups and groups_remove_member_allowed($groupid, $userid)) {
-                $icon = html_writer::tag('label', get_string('add'), array('alt'=>$straddgroup, 'class' => 'label label-primary'));
-                $url = new moodle_url($pageurl, array('action'=>'addmember', 'user'=>$userid));
-                $groupoutput .= html_writer::tag('div', html_writer::link($url, $icon), array('class'=>'addgroup'));
-                $icon = html_writer::empty_tag('img', array('alt'=>get_string('removefromgroup', 'group', $name), 'src'=>$iconenrolremove));
-                $url = new moodle_url($pageurl, array('action'=>'removemember', 'group'=>$groupid, 'user'=>$userid));
-                $groupoutput .= html_writer::tag('div', $name . html_writer::link($url, $icon), array('class'=>'group', 'rel'=>$groupid));
+                $icon = html_writer::tag('label', get_string('add'),
+                    array('alt' => $straddgroup, 'class' => 'label label-primary'));
+                $url = new moodle_url($pageurl, array('action' => 'addmember', 'user' => $userid));
+                $groupoutput .= html_writer::tag('div', html_writer::link($url, $icon), array('class' => 'addgroup'));
+                $icon = html_writer::empty_tag('img', array('alt' => get_string('removefromgroup', 'group', $name),
+                                               'src' => $iconenrolremove));
+                $url = new moodle_url($pageurl, array('action' => 'removemember', 'group' => $groupid, 'user' => $userid));
+                $groupoutput .= html_writer::tag('div', $name . html_writer::link($url, $icon),
+                    array('class' => 'group', 'rel' => $groupid));
             } else {
-                $groupoutput .= html_writer::tag('div', $name, array('class'=>'group', 'rel'=>$groupid));
+                $groupoutput .= html_writer::tag('div', $name, array('class' => 'group', 'rel' => $groupid));
             }
         }
-        $groupoutput = html_writer::tag('div', $groupoutput, array('class'=>'groups'));
+        $groupoutput = html_writer::tag('div', $groupoutput, array('class' => 'groups'));
         if ($canmanagegroups && (count($groups) < count($allgroups))) {
-            $icon = html_writer::tag('label', get_string('add'), array('alt'=>$straddgroup, 'class' => 'label label-primary'));
-            $url = new moodle_url($pageurl, array('action'=>'addmember', 'user'=>$userid));
-            $groupoutput .= html_writer::tag('div', html_writer::link($url, $icon), array('class'=>'addgroup'));
+            $icon = html_writer::tag('label', get_string('add'), array('alt' => $straddgroup, 'class' => 'label label-primary'));
+            $url = new moodle_url($pageurl, array('action' => 'addmember', 'user' => $userid));
+            $groupoutput .= html_writer::tag('div', html_writer::link($url, $icon), array('class' => 'addgroup'));
         }
         return $groupoutput;
     }

--- a/renderers/files_renderer.php
+++ b/renderers/files_renderer.php
@@ -31,7 +31,7 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
     /**
      * Returns html for displaying one file manager
      *
-     * The main element in HTML must have id="filemanager-{$client_id}" and
+     * The main element in HTML must have id="filemanager-{$clientid}" and
      * class="filemanager fm-loading";
      * After all necessary code on the page (both html and javascript) is loaded,
      * the class fm-loading will be removed and added class fm-loaded;
@@ -75,20 +75,20 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
     private function fm_print_generallayout($fm) {
         global $OUTPUT;
         $options = $fm->options;
-        $client_id = $options->client_id;
+        $clientid = $options->client_id;
         $straddfile  = get_string('addfile', 'repository');
         $strmakedir  = get_string('makeafolder', 'moodle');
         $strdownload = get_string('downloadfolder', 'repository');
         $strloading  = get_string('loading', 'repository');
         $strdroptoupload = get_string('droptoupload', 'moodle');
-        $icon_progress = $OUTPUT->pix_icon('i/loading_small', $strloading).'';
+        $iconprogress = $OUTPUT->pix_icon('i/loading_small', $strloading).'';
         $restrictions = $this->fm_print_restrictions($fm);
         $strdndnotsupported = get_string('dndnotsupported_insentence', 'moodle').$OUTPUT->help_icon('dndnotsupported');
         $strdndenabledinbox = get_string('dndenabled_inbox', 'moodle');
         $loading = get_string('loading', 'repository');
 
         $html = '
-<div id="filemanager-'.$client_id.'" class="filemanager fm-loading">
+<div id="filemanager-'.$clientid.'" class="filemanager fm-loading">
     <div class="fp-restrictions">
         '.$restrictions.'
         <span class="dnduploadnotsupported-message"> - '.$strdndnotsupported.' </span>
@@ -122,7 +122,7 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
             <span class="fp-path-folder"><a class="fp-path-folder-name" href="#"></a></span>
         </div>
     </div>
-    <div class="filemanager-loading mdl-align">'.$icon_progress.'</div>
+    <div class="filemanager-loading mdl-align">'.$iconprogress.'</div>
     <div class="filemanager-container" >
         <div class="fm-content-wrapper">
             <div class="fp-content"></div>
@@ -131,9 +131,9 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
             </div>
             <div class="dndupload-target">'.$strdroptoupload.'<br/><div class="dndupload-arrow"></div></div>
             <div class="dndupload-progressbars"></div>
-            <div class="dndupload-uploadinprogress">'.$icon_progress.'</div>
+            <div class="dndupload-uploadinprogress">'.$iconprogress.'</div>
         </div>
-        <div class="filemanager-updating">'.$icon_progress.'</div>
+        <div class="filemanager-updating">'.$iconprogress.'</div>
     </div>
 </div>';
         return $html;
@@ -377,11 +377,11 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
      * @return array
      */
     public function filemanager_js_templates() {
-        $class_methods = get_class_methods($this);
+        $classmethods = get_class_methods($this);
         $templates = array();
-        foreach ($class_methods as $method_name) {
-            if (preg_match('/^fm_js_template_(.*)$/', $method_name, $matches))
-            $templates[$matches[1]] = $this->$method_name();
+        foreach ($classmethods as $methodname) {
+            if (preg_match('/^fm_js_template_(.*)$/', $methodname, $matches))
+            $templates[$matches[1]] = $this->$methodname();
         }
         return $templates;
     }
@@ -810,7 +810,8 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
     }
 
     /**
-     * FilePicker JS template for popup dialogue window asking for action when file with the same name already exists (multiple-file version).
+     * FilePicker JS template for popup dialogue window asking for action when file with the same name
+     * already exists (multiple-file version).
      *
      * Must have one top element, CSS for this element must define width and height of the window;
      *
@@ -886,7 +887,8 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
                     <div class="controls col-md-8 fp-login-radio"><input /> <label></label></div>
                 </div>
             </div>
-            <div class="col-md-8 col-md-offset-4"><button class="fp-login-submit btn-primary btn">'.get_string('submit', 'repository').'</button></div>
+            <div class="col-md-8 col-md-offset-4"><button class="fp-login-submit btn-primary btn">'.
+            get_string('submit', 'repository').'</button></div>
         </form>
     </div>
 </div>';
@@ -899,11 +901,11 @@ class theme_bootstrap_core_files_renderer extends core_files_renderer {
      * @return array
      */
     public function filepicker_js_templates() {
-        $class_methods = get_class_methods($this);
+        $classmethods = get_class_methods($this);
         $templates = array();
-        foreach ($class_methods as $method_name) {
-            if (preg_match('/^fp_js_template_(.*)$/', $method_name, $matches))
-            $templates[$matches[1]] = $this->$method_name();
+        foreach ($classmethods as $methodname) {
+            if (preg_match('/^fp_js_template_(.*)$/', $methodname, $matches))
+            $templates[$matches[1]] = $this->$methodname();
         }
         return $templates;
     }


### PR DESCRIPTION
Result after clean up, only 2 errors left. Not sure if they are false positives though.

theme/bootstrap/renderers/maintenance_renderer.php
theme/bootstrap/renderers/course_management.php
theme/bootstrap/renderers/core_renderer.php
theme/bootstrap/renderers/files_renderer.php - 2 error(s) and 0 warning(s)
theme/bootstrap/renderers/admin_renderer.php
theme/bootstrap/renderers/enrol_renderer.php
theme/bootstrap/renderers/course_renderer.php
theme/bootstrap/renderers/course_format_renderer.php
theme/bootstrap/renderers/block_settings_renderer.php

Total: 2 error(s) and 0 warning(s)
theme/bootstrap/renderers/files_renderer.php
#383: ············if·(preg_match('/^fm_js_template_(.*)$/',·$methodname,·$matches))

Inline control structures are not allowed
#907: ············if·(preg_match('/^fp_js_template_(.*)$/',·$methodname,·$matches))

Inline control structures are not allowed
