### PR TITLE
Pass course summary through formatters for coursebox

### DIFF
--- a/renderers/course_renderer.php
+++ b/renderers/course_renderer.php
@@ -144,7 +144,7 @@ class theme_bootstrap_core_course_renderer extends core_course_renderer {
 
         // display course summary
         if ($course->has_summary()) {
-            $content .= $course->summary;
+            $content .= $chelper->get_course_formatted_summary($course);
         }
 
         // display course contacts. See course_in_list::get_course_contacts()


### PR DESCRIPTION
The course summary that displays on the homepage is showing broken image URL's using this theme in Moodle 2.7.  Looks like there is a formatting step that was missed in the implementation of the course_renderer (see core_course_renderer::coursecat_coursebox_content()).  
