### PR TITLE
Configure for livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,7 +260,8 @@ module.exports = function(grunt) {
             files: ["less/**/*.less"],
             tasks: ["compile"],
             options: {
-                spawn: false
+                spawn: false,
+                livereload: true
             }
         },
         cssflip: {


### PR DESCRIPTION
Been using grunt's livereload support for a couple of weeks to make life easier on a project at work and I do deeply dig it.

Just install one of the livereload [browser plugins](http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-) and switch on when running `grunt watch`.

Auto-browser-stylesheet-reloady good-times.
