### PR TITLE
Fix for static student gradebook alignment

### DIFF
--- a/less/moodle/grade.less
+++ b/less/moodle/grade.less
@@ -23,7 +23,11 @@
     }
 
     #user-grades {
-        margin-top: 4px;
+        margin-top: 0px;
+    }
+
+    .left_scroller {
+        padding-top: 18px;
     }
 }
 

--- a/style/moodle-rtl.css
+++ b/style/moodle-rtl.css
@@ -19832,7 +19832,11 @@ fieldset[disabled] #dock .dockedtitle.active {
 }
 
 #page-grade-report-grader-index #user-grades {
-  margin-top: 4px;
+  margin-top: 0px;
+}
+
+#page-grade-report-grader-index .left_scroller {
+  padding-top: 18px;
 }
 
 #page-grade-grading-manage #activemethodselector label {

--- a/style/moodle.css
+++ b/style/moodle.css
@@ -16420,7 +16420,10 @@ fieldset[disabled] #dock .dockedtitle.active {
   height: 1px;
 }
 #page-grade-report-grader-index #user-grades {
-  margin-top: 4px;
+  margin-top: 0px;
+}
+#page-grade-report-grader-index .left_scroller {
+  padding-top: 18px;
 }
 #page-grade-grading-manage #activemethodselector label {
   display: inline-block;


### PR DESCRIPTION
Fix for https://moodle.org/mod/forum/discuss.php?d=261626 - instead of reducing #user-grades down to 2px which affects table regardless of the core setting 'grade_report_fixedstudents' to bring into alignment, this is now set at 0px such that the scroll bar at the top is completely adjacent as the bottom one is.  Then reducing the specific '.left-scroller' (the padding on the contained table has no effect) down by 2px brings everything into alignment when 'grade_report_fixedstudents' is set.
