### PR TITLE
Use svgmin.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,8 +143,8 @@
  * grunt replace:font_fix    Correct the format for the Moodle font
  *                           loader to pick up the Glyphicon font.
  *
- * grunt replace:svg_colors  Change the color of the SVGs in pix_core by
- *                           text replacing #999 with a new hex color.
+ * grunt replace:svg_colours Change the colour of the SVGs in pix_core by
+ *                           text replacing #999 with a new hex colour.
  *                           Note this requires the SVGs to be #999 to
  *                           start with or the replace will do nothing
  *                           so should usually be preceded by copying
@@ -152,7 +152,7 @@
  *
  *                           Options:
  *
- *                           --svgcolor=<hexcolor> Hex color to use for SVGs
+ *                           --svgcolour=<hexcolour> Hex colour to use for SVGs
  *
  * grunt cssflip    Create moodle-rtl.css by flipping the direction styles
  *                  in moodle.css.
@@ -194,7 +194,7 @@ module.exports = function(grunt) {
     decachephp += 'theme_reset_all_caches();';
 
     var swatchname = grunt.option('name') || '';
-    var defaultsvgcolor = {
+    var defaultsvgcolour = {
         amelia: '#e8d069',
         bootstrap: '#428bca',
         classic: '#428bca',
@@ -216,7 +216,7 @@ module.exports = function(grunt) {
         united: '#dd4814',
         yeti: '#008cba',
     };
-    var svgcolor = grunt.option('svgcolor') || defaultsvgcolor[swatchname] || '#999';
+    var svgcolour = grunt.option('svgcolour') || defaultsvgcolour[swatchname] || '#999';
 
     grunt.initConfig({
         less: {
@@ -359,20 +359,20 @@ module.exports = function(grunt) {
                         to: '[[pix:y/lp_rtl]]'
                     }]
             },
-            svg_colors_core: {
+            svg_colours_core: {
                 src: 'pix_core/**/*.svg',
                     overwrite: true,
                     replacements: [{
                         from: '#999',
-                        to: svgcolor
+                        to: svgcolour
                     }]
             },
-            svg_colors_plugins: {
+            svg_colours_plugins: {
                 src: 'pix_plugins/**/*.svg',
                     overwrite: true,
                     replacements: [{
                         from: '#999',
-                        to: svgcolor
+                        to: svgcolour
                     }]
             },
             font_fix: {
@@ -399,6 +399,36 @@ module.exports = function(grunt) {
                         from: 'sourceMappingURL=',
                         to: 'sourceMappingURL=/theme/'+ THEMEDIR + '/style/'
                     }]
+            }
+        },
+        svgmin: {                       // Task
+            options: {                  // Configuration that will be passed directly to SVGO
+                plugins: [{
+                    removeViewBox: false
+                }, {
+                    removeUselessStrokeAndFill: false
+                }, {
+                    convertPathData: { 
+                        straightCurves: false // advanced SVGO plugin option
+                   }
+                }]
+            },
+            dist: {                     // Target
+                files: [{               // Dictionary of files
+                    expand: true,       // Enable dynamic expansion.
+                    cwd: 'pix_core',     // Src matches are relative to this path.
+                    src: ['**/*.svg'],  // Actual pattern(s) to match.
+                    dest: 'pix_core/',       // Destination path prefix.
+                    ext: '.svg'     // Dest filepaths will have this extension.
+                    // ie: optimise img/src/branding/logo.svg and store it in img/branding/logo.min.svg
+                }, {               // Dictionary of files
+                    expand: true,       // Enable dynamic expansion.
+                    cwd: 'pix_plugins',     // Src matches are relative to this path.
+                    src: ['**/*.svg'],  // Actual pattern(s) to match.
+                    dest: 'pix_plugins/',       // Destination path prefix.
+                    ext: '.svg'     // Dest filepaths will have this extension.
+                    // ie: optimise img/src/branding/logo.svg and store it in img/branding/logo.min.svg
+                }]
             }
         }
     });
@@ -480,6 +510,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-csscomb');
+    grunt.loadNpmTasks('grunt-svgmin');
 
     // Register tasks.
     grunt.registerTask("default", ["watch"]);
@@ -488,5 +519,7 @@ module.exports = function(grunt) {
     grunt.registerTask("bootswatch", _bootswatch);
     grunt.registerTask("compile", ["less", "replace:font_fix", "cssflip", "replace:rtl_images", "autoprefixer", 'csscomb', 'cssmin', "replace:sourcemap", "decache"]);
     grunt.registerTask("swatch", ["bootswatch", "svg", "compile"]);
-    grunt.registerTask("svg", ["copy:svg_core", "copy:svg_plugins", "replace:svg_colors_core", "replace:svg_colors_plugins"]);
+    grunt.registerTask("copy:svg", ["copy:svg_core", "copy:svg_plugins"]);
+    grunt.registerTask("replace:svg_colours", ["replace:svg_colours_core", "replace:svg_colours_plugins"]);
+    grunt.registerTask("svg", ["copy:svg", "replace:svg_colours", "svgmin"]);
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "grunt-css-flip": "~0.3.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-cssmin": "~0.10.0",
-    "grunt-csscomb": "~2.0.1"
+    "grunt-csscomb": "~2.0.1",
+    "grunt-svgmin": "~0.4.0"
   },
   "license": "GPL-3.0+"
 }


### PR DESCRIPTION
Hi Bas,

This is the implementation of 'svgmin' - https://github.com/sindresorhus/grunt-svgmin - which compresses the svg files between the copy and the replace tasks.  The shrinkage is not that much, but hey, it is still shrinkage:

core before:

![2014-07-25 13_49_29-pix_core properties](https://cloud.githubusercontent.com/assets/1058419/3704842/70e2afe0-1418-11e4-90b0-e8e123c3bacc.png)

core after:

![2014-07-25 16_39_28-pix_core properties](https://cloud.githubusercontent.com/assets/1058419/3704835/5ae48678-1418-11e4-8e5d-4da268b64264.png)

plugins before:

![2014-07-25 16_45_32-pix_plugins properties](https://cloud.githubusercontent.com/assets/1058419/3704852/805c7e42-1418-11e4-849a-91931f7d8c13.png)

plugins after:

![2014-07-25 16_50_36-pix_plugins properties](https://cloud.githubusercontent.com/assets/1058419/3704864/8c9fe590-1418-11e4-878c-c01e478b0d1a.png)

Cheers,

Gareth
