### PR TITLE
(Re-)Add language menu from 3.1beta bootstrapbase

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -83,8 +83,8 @@ class theme_bootstrap_core_renderer extends core_renderer {
 
     protected function render_custom_menu(custom_menu $menu) {
 
-        // TODO: eliminate this duplicated logic, it belongs in core, not
-        // here. See MDL-39565.
+        // Add the lang_menu to the left of the menu.
+        $this->add_lang_menu($menu);
 
         $content = '<ul class="nav navbar-nav pull-right">';
         foreach ($menu->get_children() as $item) {
@@ -245,6 +245,33 @@ class theme_bootstrap_core_renderer extends core_renderer {
             }
         }
         return $content;
+    }
+
+    /**
+     * Adds a lang submenu in a custom_menu
+     *
+     * @return string The lang menu HTML or empty string
+     */
+    protected function add_lang_menu(custom_menu $menu, $force = false) {
+        // TODO: eliminate this duplicated logic, it belongs in core, not
+        // here. See MDL-39565.
+
+        $haslangmenu = $this->lang_menu() != '';
+
+        if ($force || ( !empty($this->page->layout_options['langmenu']) && $haslangmenu ) ) {
+            $langs = get_string_manager()->get_list_of_translations();
+            $strlang = get_string('language');
+            $currentlang = current_language();
+            if (isset($langs[$currentlang])) {
+                $currentlang = $langs[$currentlang];
+            } else {
+                $currentlang = $strlang;
+            }
+            $this->language = $menu->add($currentlang, new moodle_url('#'), $strlang, 10000);
+            foreach ($langs as $langtype => $langname) {
+                $this->language->add($langname, new moodle_url($this->page->url, array('lang' => $langtype)), $langname);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
On Moodle 3.1beta; without this, theme/bootstrap displays no language menu at all.

This is arguably duplicated code, but it is needed as long as core doesn't have a generic way to create it.