### PR TITLE
Ignore IntelliJ project meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Thumbs.db
 *.swp
 sourcemap-moodle.json
 sourcemap-editor.json
+.idea
+*.iml


### PR DESCRIPTION
IntelliJ and PHPStorm create .idea directories in project roots to store local setup / config. Additionally IntelliJ also creates *.iml module library files.

As the Jetbrains IDEs are increasingly popular among PHP devs would be great to include these in the gitignore (and stop them showing up in my local dev environment ;D ).