### PR TITLE
Consolidate jshint directives

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,23 +96,25 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-module.exports = function(grunt) { // jshint ignore:line
+// jshint node: true, strict: false
+
+module.exports = function(grunt) {
 
     // Import modules.
     var path = require('path');
 
     // PHP strings for exec task.
-    var moodleroot = path.dirname(path.dirname(__dirname)), // jshint ignore:line
+    var moodleroot = path.dirname(path.dirname(__dirname)),
         configfile = '',
         decachephp = '',
-        dirrootopt = grunt.option('dirroot') || process.env.MOODLE_DIR || ''; // jshint ignore:line
+        dirrootopt = grunt.option('dirroot') || process.env.MOODLE_DIR || '';
 
     // Allow user to explicitly define Moodle root dir.
     if ('' !== dirrootopt) {
         moodleroot = path.resolve(dirrootopt);
     }
 
-    var PWD = process.cwd(); // jshint ignore:line
+    var PWD = process.cwd();
     configfile = path.join(moodleroot, 'config.php');
 
     decachephp += 'define(\'CLI_SCRIPT\', true);';


### PR DESCRIPTION
Noticed that there are a few lines which have jshint ignore directives due to node specific syntax causing linting errors.

This patch consolidates these by setting the jshint environment to node instead. I also noticed I was getting an error due to a missing `'use strict'` inside `module.exports`. The core Gruntfile doesn't use strict mode so should probably stay consistent with this for now therefore have also switched this warning off.