### PR TITLE
#424 remove amd task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,6 @@ module.exports = function(grunt) {
         moodleroot = path.resolve(dirrootopt);
     }
 
-    var PWD = process.cwd();
     configfile = path.join(moodleroot, 'config.php');
 
     decachephp += 'define(\'CLI_SCRIPT\', true);';

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,10 +50,6 @@
  *                                 when your theme is not in the
  *                                 standard location.
  *
- * grunt amd     Create the Asynchronous Module Definition JavaScript files.  See: MDL-49046.
- *               Done here as core Gruntfile.js currently *nix only.
- *
- *
  *
  * Plumbing tasks & targets:
  * -------------------------
@@ -102,6 +98,7 @@ module.exports = function(grunt) {
 
     // Import modules.
     var path = require('path');
+    var os = require('os');
 
     // PHP strings for exec task.
     var moodleroot = path.dirname(path.dirname(__dirname)),
@@ -240,27 +237,6 @@ module.exports = function(grunt) {
                     to: '[[pix:y/lp_rtl]]'
                 }]
             }
-        },
-        jshint: {
-            options: {jshintrc: moodleroot + '/.jshintrc'},
-            files: ['**/amd/src/*.js']
-        },
-        uglify: {
-            dynamic_mappings: {
-                files: grunt.file.expandMapping(
-                    ['**/src/*.js', '!**/node_modules/**'],
-                    '',
-                    {
-                        cwd: PWD,
-                        rename: function(destBase, destPath) {
-                            destPath = destPath.replace('src', 'build');
-                            destPath = destPath.replace('.js', '.min.js');
-                            destPath = path.resolve(PWD, destPath);
-                            return destPath;
-                        }
-                    }
-                )
-            }
         }
     });
 
@@ -275,10 +251,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-csscomb');
 
-    // Load core tasks.
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-
     // Register tasks.
     grunt.registerTask("default", ["watch"]);
     grunt.registerTask("decache", ["exec:decache"]);
@@ -290,6 +262,18 @@ module.exports = function(grunt) {
         "autoprefixer",
         'csscomb',
         'cssmin',
-        "decache"]);
-    grunt.registerTask("amd", ["jshint", "uglify", "decache"]);
+        "decache"
+    ]);
+
+    grunt.registerTask('amd', function() {
+        grunt.fail.warn([
+            "The task 'amd' is not configured in the theme Gruntfile.",
+            'Specify the path to your $CFG->dirroot Gruntfile e.g.',
+            '',
+            'grunt amd --gruntfile="/path/to/dirroot/Gruntfile.js"',
+            '',
+            ''
+        ].join(os.EOL));
+    });
+
 };

--- a/package.json
+++ b/package.json
@@ -8,9 +8,17 @@
     "url": "http://www.iamjoby.com"
   },
   "contributors": [
-    { "name": "David Scotson" },
-    { "name": "Bas Brands", "url": "http://www.basbrands.nl" },
-    { "name": "Gareth J Barnard", "url": "http://about.me/gjbarnard" }
+    {
+      "name": "David Scotson"
+    },
+    {
+      "name": "Bas Brands",
+      "url": "http://www.basbrands.nl"
+    },
+    {
+      "name": "Gareth J Barnard",
+      "url": "http://about.me/gjbarnard"
+    }
   ],
   "repository": {
     "type": "git",
@@ -22,17 +30,15 @@
   "dependencies": {
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "~0.7.6",
-    "grunt-contrib-less": "~0.11.3",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-exec": "~0.4.5",
-    "grunt-text-replace": "~0.3.11",
-    "grunt-css-flip": "~0.4.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-less": "~0.11.3",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-css-flip": "~0.4.0",
     "grunt-csscomb": "~2.0.1",
-    "grunt-contrib-jshint": "~0.11.0",
-    "grunt-contrib-uglify": "~0.7.0",
-    "grunt-svgmin": "~0.4.0"
+    "grunt-exec": "~0.4.5",
+    "grunt-svgmin": "~0.4.0",
+    "grunt-text-replace": "~0.3.11"
   },
   "license": "GPL-3.0+"
 }


### PR DESCRIPTION
OK false alarm on `os` mentioned in #426 however I did realise that removing the `amd` task means that `grunt-contrib-jshint` and `grunt-contrib-uglify` are no longer needed so I've removed those also.

Using `npm uninstall --save` appears to have done some of its own JSON reformatting too which is why some additional lines in package.json have changed.