### PR TITLE
Delete config for removed function

### DIFF
--- a/config.php
+++ b/config.php
@@ -51,7 +51,6 @@ $THEME->plugins_exclude_sheets = array(
 );
 
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';
-$THEME->csspostprocess = 'theme_bootstrap_process_css';
 
 $THEME->layouts = array(
     // Most backwards compatible layout without the blocks - this is the layout used by default.


### PR DESCRIPTION
The function `theme_bootstrap_process_css` was removed in commit 063161f29299bb0a9eddaa89600d2c617e76a4bf

It didn't cause any problems as Moodle checks if the function exists before calling it but ought to remove.