### PR TITLE
Update license info

### DIFF
--- a/thirdpartylibs.xml
+++ b/thirdpartylibs.xml
@@ -3,8 +3,8 @@
   <library>
     <location>less/bootstrap3-3-6</location>
     <name>Bootstrap</name>
-    <license>Apache</license>
+    <license>MIT</license>
     <version>3.3.6</version>
-    <licenseversion>2.0</licenseversion>
+    <licenseversion></licenseversion>
   </library>
 </libraries>


### PR DESCRIPTION
The license info in `thirdpartylibs.xml` is outdated (looks like the Bootstrap 2 license).

The MIT license doesn't have a version number currently so the corresponding XML element is empty. This is consistent with the way other third party libs licensed under the MIT are entered e.g. jQuery listed in `lib/thirdpartylibs.xml` in the core codebase.