### PR TITLE
Prevent overlap of edit dropdown on hidden topics; fixes #324 and #389

### DIFF
--- a/less/moodle/course.less
+++ b/less/moodle/course.less
@@ -251,7 +251,11 @@
             }
         }
         li.section.hidden {
-            .opacity(.5);
+            .sectionname > span,
+            .content > div,
+            .activity .activityinstance {
+                opacity: .5;
+            }
         }
     }
 }


### PR DESCRIPTION
Adapted from the core solution to MDL-42634. Grunt's doing weird things with whitespace so I didn't compile the LESS. This is developing into a pretty big problem at our institution unfortunately.